### PR TITLE
Focus frames beneath a node on dblclick

### DIFF
--- a/flamechart-view.tsx
+++ b/flamechart-view.tsx
@@ -399,6 +399,17 @@ export class FlamechartPanZoomView extends ReloadableComponent<FlamechartPanZoom
     }
   }
 
+  private onDblClick = (ev: MouseEvent) => {
+    if (this.hoveredLabel) {
+      const hoveredBounds = this.hoveredLabel.configSpaceBounds
+      const viewportRect = new Rect(
+        hoveredBounds.origin.minus(new Vec2(0, 1)),
+        hoveredBounds.size.withY(this.props.configSpaceViewportRect.height())
+      )
+      this.props.setConfigSpaceViewportRect(viewportRect)
+    }
+  }
+
   private updateCursor() {
     if (this.lastDragPos) {
       document.body.style.cursor = 'grabbing'
@@ -544,6 +555,7 @@ export class FlamechartPanZoomView extends ReloadableComponent<FlamechartPanZoom
         onMouseDown={this.onMouseDown}
         onMouseMove={this.onMouseMove}
         onMouseLeave={this.onMouseLeave}
+        onDblClick={this.onDblClick}
         onWheel={this.onWheel}
         ref={this.containerRef}>
         <canvas


### PR DESCRIPTION
As discussed: double clicking a node will position that node at the top left of the view, and resize horizontally to fit that node.

<img width="1018" alt="screen shot 2018-01-30 at 23 38 19" src="https://user-images.githubusercontent.com/984857/35605447-c2a80868-0616-11e8-9bb8-c28851f2b3d5.png">

becomes

<img width="1018" alt="screen shot 2018-01-30 at 23 38 34" src="https://user-images.githubusercontent.com/984857/35605475-e662cb94-0616-11e8-9014-4e319959bce4.png">