### PR TITLE
Add a detail view to view aggregate statistics & file details

### DIFF
--- a/application.tsx
+++ b/application.tsx
@@ -592,7 +592,7 @@ const style = StyleSheet.create({
     cursor: 'pointer',
   },
   link: {
-    color: Colors.LIGHT_BLUE,
+    color: Colors.BRIGHT_BLUE,
     cursor: 'pointer',
     textDecoration: 'none',
   },
@@ -639,9 +639,9 @@ const style = StyleSheet.create({
     },
   },
   toolbarTabActive: {
-    background: Colors.LIGHT_BLUE,
+    background: Colors.BRIGHT_BLUE,
     ':hover': {
-      background: Colors.LIGHT_BLUE,
+      background: Colors.BRIGHT_BLUE,
     },
   },
   noLinkStyle: {

--- a/color.ts
+++ b/color.ts
@@ -1,5 +1,3 @@
-import {Frame} from './profile'
-
 export class Color {
   constructor(
     readonly r: number = 0,
@@ -30,56 +28,10 @@ export class Color {
 
     return new Color(R1 + m, G1 + m, B1 + m, 1.0)
   }
-}
 
-function fract(x: number) {
-  return x - Math.floor(x)
-}
-
-// TODO(jlfwong): Can probably delete this?
-export class FrameColorGenerator {
-  private frameToColor = new Map<Frame, Color>()
-
-  constructor(frames: Frame[]) {
-    // Make a copy so we can mutate it
-    frames = [...frames]
-
-    function key(f: Frame) {
-      return (f.file || '') + f.name
-    }
-
-    function compare(a: Frame, b: Frame) {
-      return key(a) > key(b) ? 1 : -1
-    }
-
-    frames.sort(compare)
-
-    const cumulativeScores: number[] = []
-    let lastScore = 0
-    for (let i = 0; i < frames.length; i++) {
-      const score = lastScore + Math.abs(compare(frames[i], frames[(i + 1) % frames.length]))
-      cumulativeScores.push(score)
-      lastScore = score
-    }
-
-    // We now have a sorted list of frames s.t. frames with similar
-    // file paths and method names are clustered together.
-    //
-    // Now, to assign them colors, we map normalized cumulative
-    // score values onto the full range of hue values.
-    const totalScore = cumulativeScores[cumulativeScores.length - 1] || 1
-    for (let i = 0; i < cumulativeScores.length; i++) {
-      const ratio = cumulativeScores[i] / totalScore
-      const x = 2 * fract(100.0 * ratio) - 1
-
-      const L = 0.85 - 0.1 * x
-      const C = 0.2 + 0.1 * x
-      const H = 360 * ratio
-      this.frameToColor.set(frames[i], Color.fromLumaChromaHue(L, C, H))
-    }
-  }
-
-  getColorForFrame(f: Frame) {
-    return this.frameToColor.get(f) || new Color()
+  toCSS(): string {
+    return `rgba(${(255 * this.r).toFixed()}, ${(255 * this.g).toFixed()}, ${(
+      255 * this.b
+    ).toFixed()}, ${this.a.toFixed(2)})`
   }
 }

--- a/flamechart-style.ts
+++ b/flamechart-style.ts
@@ -74,6 +74,14 @@ export const style = StyleSheet.create({
     lineHeight: `${FontSize.LABEL + 2}px`,
     padding: 5,
   },
+  stackChit: {
+    display: 'inline-block',
+    verticalAlign: 'bottom',
+    marginRight: '0.5em',
+    border: `1px solid ${Colors.MEDIUM_GRAY}`,
+    width: FontSize.LABEL - 2,
+    height: FontSize.LABEL - 2,
+  },
   stackLine: {
     whiteSpace: 'nowrap',
   },

--- a/flamechart-style.ts
+++ b/flamechart-style.ts
@@ -83,6 +83,7 @@ export const style = StyleSheet.create({
   statsTable: {
     display: 'grid',
     gridTemplateColumns: '1fr 1fr',
+    gridTemplateRows: `repeat(3, ${FontSize.LABEL + 10}px)`,
     gridGap: '1px 1px',
     textAlign: 'center',
     paddingRight: 1,
@@ -92,6 +93,8 @@ export const style = StyleSheet.create({
   },
   statsTableCell: {
     position: 'relative',
+    display: 'flex',
+    justifyContent: 'center',
     alignItems: 'center',
   },
   thisInstanceCell: {
@@ -107,6 +110,6 @@ export const style = StyleSheet.create({
     top: 0,
     left: 0,
     background: 'rgba(0, 0, 0, 0.2)',
-    height: '100%',
+    width: '100%',
   },
 })

--- a/flamechart-style.ts
+++ b/flamechart-style.ts
@@ -77,7 +77,7 @@ export const style = StyleSheet.create({
   stackLine: {
     whiteSpace: 'nowrap',
   },
-  stackLinePos: {
+  stackFileLine: {
     color: Colors.MEDIUM_GRAY,
   },
   statsTable: {
@@ -95,10 +95,12 @@ export const style = StyleSheet.create({
     alignItems: 'center',
   },
   thisInstanceCell: {
-    background: Colors.LIGHT_BLUE,
+    background: Colors.DARK_BLUE,
+    color: 'white',
   },
   allInstancesCell: {
-    background: Colors.LIGHTER_BLUE,
+    background: Colors.PALE_DARK_BLUE,
+    color: 'white',
   },
   barDisplay: {
     position: 'absolute',

--- a/flamechart-style.ts
+++ b/flamechart-style.ts
@@ -5,6 +5,7 @@ const HOVERTIP_PADDING = 2
 
 export namespace Sizes {
   export const MINIMAP_HEIGHT = 100
+  export const DETAIL_VIEW_HEIGHT = 150
   export const TOOLTIP_WIDTH_MAX = 300
   export const TOOLTIP_HEIGHT_MAX = 75
   export const SEPARATOR_HEIGHT = 2
@@ -56,5 +57,54 @@ export const style = StyleSheet.create({
   },
   panZoomView: {
     flex: 1,
+  },
+
+  detailView: {
+    display: 'grid',
+    height: Sizes.DETAIL_VIEW_HEIGHT,
+    overflow: 'hidden',
+    gridTemplateColumns: '120px 120px 1fr',
+    gridTemplateRows: 'repeat(4, 1fr)',
+    borderTop: `${Sizes.SEPARATOR_HEIGHT}px solid ${Colors.MEDIUM_GRAY}`,
+    fontSize: FontSize.LABEL,
+  },
+  stackTraceView: {
+    height: Sizes.DETAIL_VIEW_HEIGHT,
+    overflow: 'auto',
+    lineHeight: `${FontSize.LABEL + 2}px`,
+    padding: 5,
+  },
+  stackLine: {
+    whiteSpace: 'nowrap',
+  },
+  stackLinePos: {
+    color: Colors.MEDIUM_GRAY,
+  },
+  statsTable: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gridGap: '1px 1px',
+    textAlign: 'center',
+    paddingRight: 1,
+  },
+  statsTableHeader: {
+    gridColumn: '1 / 3',
+  },
+  statsTableCell: {
+    position: 'relative',
+    alignItems: 'center',
+  },
+  thisInstanceCell: {
+    background: Colors.LIGHT_BLUE,
+  },
+  allInstancesCell: {
+    background: Colors.LIGHTER_BLUE,
+  },
+  barDisplay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    background: 'rgba(0, 0, 0, 0.2)',
+    height: '100%',
   },
 })

--- a/flamechart-style.ts
+++ b/flamechart-style.ts
@@ -67,6 +67,10 @@ export const style = StyleSheet.create({
     gridTemplateRows: 'repeat(4, 1fr)',
     borderTop: `${Sizes.SEPARATOR_HEIGHT}px solid ${Colors.MEDIUM_GRAY}`,
     fontSize: FontSize.LABEL,
+    position: 'absolute',
+    background: 'white',
+    width: '100vw',
+    bottom: 0,
   },
   stackTraceView: {
     height: Sizes.DETAIL_VIEW_HEIGHT,

--- a/flamechart-view.tsx
+++ b/flamechart-view.tsx
@@ -365,7 +365,7 @@ export class FlamechartPanZoomView extends ReloadableComponent<FlamechartPanZoom
   }
 
   private lastBounds: ClientRect | null = null
-  private updateConfigSpaceViewport(windowResized = false) {
+  private updateConfigSpaceViewport() {
     if (!this.container) return
     const bounds = this.container.getBoundingClientRect()
     const {width, height} = bounds
@@ -380,7 +380,7 @@ export class FlamechartPanZoomView extends ReloadableComponent<FlamechartPanZoom
           new Vec2(this.configSpaceSize().x, height / this.LOGICAL_VIEW_SPACE_FRAME_HEIGHT),
         ),
       )
-    } else if (windowResized) {
+    } else if (this.lastBounds.width !== width || this.lastBounds.height !== height) {
       // Resize the viewport rectangle to match the window size aspect
       // ratio.
       this.setConfigSpaceViewportRect(
@@ -395,7 +395,7 @@ export class FlamechartPanZoomView extends ReloadableComponent<FlamechartPanZoom
   }
 
   onWindowResize = () => {
-    this.updateConfigSpaceViewport(true)
+    this.updateConfigSpaceViewport()
     this.onBeforeFrame()
   }
 
@@ -942,14 +942,6 @@ export class FlamechartView extends ReloadableComponent<FlamechartViewProps, Fla
         </div>
       </div>
     )
-  }
-
-  componentDidUpdate(prevProps: FlamechartViewProps, prevState: FlamechartViewState) {
-    if ((this.state.selectedNode == null) !== (prevState.selectedNode == null)) {
-      if (this.panZoomView) {
-        this.panZoomView.onWindowResize()
-      }
-    }
   }
 
   containerRef = (container?: Element) => {

--- a/flamechart-view.tsx
+++ b/flamechart-view.tsx
@@ -760,15 +760,11 @@ class StackTraceView extends ReloadableComponent<StackTraceViewProps, {}> {
 
 interface FlamechartDetailViewProps {
   flamechart: Flamechart
-  selectedNode: CallTreeNode | null
+  selectedNode: CallTreeNode
 }
 
 class FlamechartDetailView extends ReloadableComponent<FlamechartDetailViewProps, {}> {
   render() {
-    if (this.props.selectedNode == null) {
-      return <div className={css(style.detailView)} />
-    }
-
     const {flamechart, selectedNode} = this.props
     const {frame} = selectedNode
 
@@ -920,6 +916,14 @@ export class FlamechartView extends ReloadableComponent<FlamechartViewProps, Fla
     )
   }
 
+  componentDidUpdate(prevProps: FlamechartViewProps, prevState: FlamechartViewState) {
+    if ((this.state.selectedNode == null) !== (prevState.selectedNode == null)) {
+      if (this.panZoomView) {
+        this.panZoomView.onWindowResize()
+      }
+    }
+  }
+
   containerRef = (container?: Element) => {
     this.container = (container as HTMLDivElement) || null
   }
@@ -957,10 +961,12 @@ export class FlamechartView extends ReloadableComponent<FlamechartViewProps, Fla
           configSpaceViewportRect={this.state.configSpaceViewportRect}
           setConfigSpaceViewportRect={this.setConfigSpaceViewportRect}
         />
-        <FlamechartDetailView
-          flamechart={this.props.flamechart}
-          selectedNode={this.state.selectedNode}
-        />
+        {this.state.selectedNode && (
+          <FlamechartDetailView
+            flamechart={this.props.flamechart}
+            selectedNode={this.state.selectedNode}
+          />
+        )}
         {this.renderTooltip()}
       </div>
     )

--- a/flamechart-view.tsx
+++ b/flamechart-view.tsx
@@ -716,11 +716,11 @@ class StatisticsTable extends ReloadableComponent<StatisticsTableProps, {}> {
 
         <div className={css(this.props.cellStyle, style.statsTableCell)}>
           {formatPercent(totalPerc)}
-          <div className={css(style.barDisplay)} style={{width: `${totalPerc}%`}} />
+          <div className={css(style.barDisplay)} style={{height: `${totalPerc}%`}} />
         </div>
         <div className={css(this.props.cellStyle, style.statsTableCell)}>
           {formatPercent(selfPerc)}
-          <div className={css(style.barDisplay)} style={{width: `${selfPerc}%`}} />
+          <div className={css(style.barDisplay)} style={{height: `${selfPerc}%`}} />
         </div>
       </div>
     )

--- a/style.ts
+++ b/style.ts
@@ -15,6 +15,5 @@ export enum Colors {
   DARK_GRAY = '#222222',
   BRIGHT_BLUE = '#56CCF2',
   DARK_BLUE = '#2F80ED',
-  LIGHT_BLUE = '#ABE6F9',
-  LIGHTER_BLUE = '#DDF5FC',
+  PALE_DARK_BLUE = '#8EB7ED',
 }

--- a/style.ts
+++ b/style.ts
@@ -13,6 +13,8 @@ export enum Colors {
   MEDIUM_GRAY = '#BDBDBD',
   GRAY = '#666666',
   DARK_GRAY = '#222222',
-  LIGHT_BLUE = '#56CCF2',
+  BRIGHT_BLUE = '#56CCF2',
   DARK_BLUE = '#2F80ED',
+  LIGHT_BLUE = '#ABE6F9',
+  LIGHTER_BLUE = '#DDF5FC',
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/150329/38852391-9706fb4e-41ce-11e8-8296-a236928820c6.png)

This introduces a view for showing detailed information about a selected frame in the flamegraph. This provides information about self time & aggregate times across all instances of the function, regardless of where it is in the flamegraph.

This also shows a full stack with file & line information.

Fixes #20 