### PR TITLE
Change the public asset directory to be top level now that we have a domain

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -22,7 +22,7 @@ date > "$OUTDIR"/release.txt
 git rev-parse HEAD >> "$OUTDIR"/release.txt
 
 # Build the compiled assets
-node_modules/.bin/parcel build index.html --out-dir "$OUTDIR" --public-url /speedscope/ --detailed-report
+node_modules/.bin/parcel build index.html --out-dir "$OUTDIR" --public-url / --detailed-report
 
 # Create a shallow clone of the repository
 TMPDIR=`mktemp -d -t speedscope-release`
@@ -34,7 +34,6 @@ git clone --depth 1 git@github.com:jlfwong/speedscope.git -b gh-pages
 pushd speedscope
 rm -rf *
 cp -R "$OUTDIR"/* .
-popd
 
 # Set up a handler to run on Ctrl+C
 trap ctrl_c INT
@@ -61,7 +60,7 @@ function ctrl_c() {
 # Start a local server for verification of the build
 echo
 echo
-echo "Build complete. Starting server on http://localhost:4444/speedscope/"
+echo "Build complete. Starting server on http://localhost:4444/"
 echo "Hit Ctrl+C to complete or cancel the release"
 echo
 echo


### PR DESCRIPTION
We previously had to serve from `/speedscope/` because the website was https://jlfwong.github.io/speedscope/. Now that we're going to serve from https://www.speedscope.app, we no longer have to do that (in fact it's important that we don't do that).