### PR TITLE
Fixes for details view

### DIFF
--- a/flamechart-style.ts
+++ b/flamechart-style.ts
@@ -72,11 +72,13 @@ export const style = StyleSheet.create({
     width: '100vw',
     bottom: 0,
   },
+  stackTraceViewPadding: {
+    padding: 5,
+  },
   stackTraceView: {
     height: Sizes.DETAIL_VIEW_HEIGHT,
-    overflow: 'auto',
     lineHeight: `${FontSize.LABEL + 2}px`,
-    padding: 5,
+    overflow: 'auto',
   },
   stackChit: {
     display: 'inline-block',

--- a/flamechart-view.tsx
+++ b/flamechart-view.tsx
@@ -736,7 +736,7 @@ class StackTraceView extends ReloadableComponent<StackTraceViewProps, {}> {
   render() {
     const rows: JSX.Element[] = []
     let node: CallTreeNode | null = this.props.node
-    for (; node; node = node.parent) {
+    for (; node && !node.isRoot(); node = node.parent) {
       const row: (JSX.Element | string)[] = []
       const {frame} = node
 
@@ -764,7 +764,11 @@ class StackTraceView extends ReloadableComponent<StackTraceViewProps, {}> {
       }
       rows.push(<div className={css(style.stackLine)}>{row}</div>)
     }
-    return <div className={css(style.stackTraceView)}>{rows}</div>
+    return (
+      <div className={css(style.stackTraceView)}>
+        <div className={css(style.stackTraceViewPadding)}>{rows}</div>
+      </div>
+    )
   }
 }
 

--- a/import/instruments.ts
+++ b/import/instruments.ts
@@ -601,7 +601,7 @@ function expandKeyedArchive(
   // Sanity checks
   if (
     root.$version !== 100000 ||
-    (root.$archiver !== 'MSArchiver' && root.$archiver !== 'NSKeyedArchiver') ||
+    root.$archiver !== 'NSKeyedArchiver' ||
     !isDictionary(root.$top) ||
     !isArray(root.$objects)
   ) {

--- a/profile.ts
+++ b/profile.ts
@@ -68,6 +68,11 @@ export class Frame extends HasWeights {
 
 export class CallTreeNode extends HasWeights {
   children: CallTreeNode[] = []
+
+  isRoot() {
+    return this.frame === rootFrame
+  }
+
   constructor(readonly frame: Frame, readonly parent: CallTreeNode | null) {
     super()
   }


### PR DESCRIPTION
This contains 2 fixes for the details view
The first is that the padding in the scrolling view was causing the last frame to be clipped
The second is that we were uselessly displaying "(speedscope root)" in the stack trace view.

This also removes some sketch specific stuff from the keyed archive expanding code

Fixes #32 