### PR TITLE
Update instruments import to use integeruniquer.index file

### DIFF
--- a/sample/profiles/Instruments/8.3.3/integer-uniquer-data.grammar
+++ b/sample/profiles/Instruments/8.3.3/integer-uniquer-data.grammar
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ufwb version="1.17">
-    <grammar name="Integer Uniquer Data" start="id:165" author="Jamie Wong">
+    <grammar name="Integer Uniquer Data" start="id:1" author="Jamie Wong">
         <description>Grammar for my file format</description>
-        <structure name="Root" id="165" encoding="ISO_8859-1:1987" endian="little" signed="no">
-            <binary name="Header" id="166" length="32"/>
-            <structure name="Array" id="167" repeatmax="-1">
-                <number name="Size" id="168" fillcolor="CEFFD2" type="integer" length="4"/>
-                <structure name="Data" id="169" repeatmin="Size" repeatmax="Size">
-                    <number name="Value" id="170" type="integer" length="8"/>
+        <structure name="Root" id="1" encoding="ISO_8859-1:1987" endian="little" signed="no">
+            <binary name="integeruniquer.data file" id="2" length="32"/>
+            <structure name="Array" id="3" repeatmax="-1">
+                <number name="Size" id="4" fillcolor="CEFFD2" type="integer" length="4"/>
+                <structure name="Data" id="5" repeatmin="Size" repeatmax="Size">
+                    <number name="Value" id="6" type="integer" length="8"/>
                 </structure>
             </structure>
         </structure>

--- a/sample/profiles/Instruments/8.3.3/integer-uniquer-index.grammar
+++ b/sample/profiles/Instruments/8.3.3/integer-uniquer-index.grammar
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ufwb version="1.17">
+    <grammar name="INDEX grammar" start="id:10" author="Jamie Wong" fileextension="index">
+        <description>Grammar for INDEX files</description>
+        <structure name="integeruniquer.index file" id="10" encoding="ISO_8859-1:1987" endian="big" signed="no">
+            <binary name="Header" id="12" length="32"/>
+            <structure name="Entry" id="16" length="8" repeatmax="-1">
+                <number name="ByteOffset" id="15" type="integer" length="4" endian="little"/>
+                <number name="MegabyteOffset" id="18" type="integer" length="4" endian="little"/>
+            </structure>
+        </structure>
+    </grammar>
+</ufwb>


### PR DESCRIPTION
I knew early on that `integeruniquer.index` could be used to index into `integeruniquer.data`, but I initially thought it was an optimization rather than a necessity. It seems like if there's data past the 1MB threshold in `integeruniquer.data`, then `integeruniquer.index` is actually quite useful.

The file seems to contain `[byte offset, MB offset]` pairs encoded as two 32 bit unsigned little endian integers. Using that to decode the integer arrays encoded in `integeruniquer.data` allows the file in #63 to load.

Fixes #63 