### PR TITLE
Add a hotkey to flatten recursion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true,
+}

--- a/flamechart-renderer.ts
+++ b/flamechart-renderer.ts
@@ -103,7 +103,7 @@ interface FlamechartRowAtlasKeyInfo {
   index: number
 }
 
-class FlamechartRowAtlasKey {
+export class FlamechartRowAtlasKey {
   readonly stackDepth: number
   readonly zoomLevel: number
   readonly index: number
@@ -123,13 +123,15 @@ class FlamechartRowAtlasKey {
 
 export class FlamechartRenderer {
   private layers: RangeTreeNode[] = []
-  private rowAtlas: RowAtlas<FlamechartRowAtlasKey>
   private rectInfoTexture: regl.Texture
   private framebuffer: regl.Framebuffer
 
-  constructor(private canvasContext: CanvasContext, private flamechart: Flamechart) {
+  constructor(
+    private canvasContext: CanvasContext,
+    private rowAtlas: RowAtlas<FlamechartRowAtlasKey>,
+    private flamechart: Flamechart,
+  ) {
     const nLayers = flamechart.getLayers().length
-    this.rowAtlas = new RowAtlas(canvasContext)
     for (let stackDepth = 0; stackDepth < nLayers; stackDepth++) {
       const leafNodes: RangeTreeLeafNode[] = []
       const y = stackDepth

--- a/flamechart-renderer.ts
+++ b/flamechart-renderer.ts
@@ -3,99 +3,11 @@ import {Flamechart} from './flamechart'
 import {RectangleBatch} from './rectangle-batch-renderer'
 import {CanvasContext} from './canvas-context'
 import {Vec2, Rect, AffineTransform} from './math'
-import {LRUCache} from './lru-cache'
 import {Color} from './color'
 import {KeyedSet} from './utils'
+import {RowAtlas} from './row-atlas'
 
 const MAX_BATCH_SIZE = 10000
-
-class RowAtlas<K> {
-  texture: regl.Texture
-  private framebuffer: regl.Framebuffer
-  private renderToFramebuffer: regl.Command<{}>
-  private rowCache: LRUCache<K, number>
-  private clearLineBatch: RectangleBatch
-
-  constructor(private canvasContext: CanvasContext) {
-    this.texture = canvasContext.gl.texture({
-      width: Math.min(canvasContext.getMaxTextureSize(), 4096),
-      height: Math.min(canvasContext.getMaxTextureSize(), 1024),
-      wrapS: 'clamp',
-      wrapT: 'clamp',
-    })
-    this.framebuffer = canvasContext.gl.framebuffer({color: [this.texture]})
-    this.rowCache = new LRUCache(this.texture.height)
-    this.renderToFramebuffer = canvasContext.gl({
-      framebuffer: this.framebuffer,
-    })
-    this.clearLineBatch = canvasContext.createRectangleBatch()
-    this.clearLineBatch.addRect(Rect.unit, new Color(0, 0, 0, 0))
-  }
-
-  has(key: K) {
-    return this.rowCache.has(key)
-  }
-  getResolution() {
-    return this.texture.width
-  }
-  getCapacity() {
-    return this.texture.height
-  }
-
-  private allocateLine(key: K): number {
-    if (this.rowCache.getSize() < this.rowCache.getCapacity()) {
-      // Not in cache, but cache isn't full
-      const row = this.rowCache.getSize()
-      this.rowCache.insert(key, row)
-      return row
-    } else {
-      // Not in cache, and cache is full. Evict something.
-      const [, row] = this.rowCache.removeLRU()!
-      this.rowCache.insert(key, row)
-      return row
-    }
-  }
-
-  writeToAtlasIfNeeded(keys: K[], render: (textureDstRect: Rect, key: K) => void) {
-    this.renderToFramebuffer((context: regl.Context) => {
-      for (let key of keys) {
-        let row = this.rowCache.get(key)
-        if (row != null) {
-          // Already cached!
-          continue
-        }
-        // Not cached -- we'll have to actually render
-        row = this.allocateLine(key)
-
-        const textureRect = new Rect(new Vec2(0, row), new Vec2(this.texture.width, 1))
-        this.canvasContext.drawRectangleBatch({
-          batch: this.clearLineBatch,
-          configSpaceSrcRect: Rect.unit,
-          physicalSpaceDstRect: textureRect,
-        })
-        render(textureRect, key)
-      }
-    })
-  }
-
-  renderViaAtlas(key: K, dstRect: Rect): boolean {
-    let row = this.rowCache.get(key)
-    if (row == null) {
-      return false
-    }
-
-    const textureRect = new Rect(new Vec2(0, row), new Vec2(this.texture.width, 1))
-
-    // At this point, we have the row in cache, and we can
-    // paint directly from it into the framebuffer.
-    this.canvasContext.drawTexture({
-      texture: this.texture,
-      srcRect: textureRect,
-      dstRect: dstRect,
-    })
-    return true
-  }
-}
 
 interface RangeTreeNode {
   getBounds(): Rect

--- a/flamechart.ts
+++ b/flamechart.ts
@@ -19,7 +19,7 @@ interface FlamechartDataSource {
 
   forEachCall(
     openFrame: (node: CallTreeNode, value: number) => void,
-    closeFrame: (value: number) => void,
+    closeFrame: (node: CallTreeNode, value: number) => void,
   ): void
 
   getColorBucketForFrame(f: Frame): number
@@ -65,7 +65,7 @@ export class Flamechart {
     }
 
     this.minFrameWidth = Infinity
-    const closeFrame = (value: number) => {
+    const closeFrame = (node: CallTreeNode, value: number) => {
       console.assert(stack.length > 0)
       const stackTop = stack.pop()!
       stackTop.end = value

--- a/profile.test.ts
+++ b/profile.test.ts
@@ -39,7 +39,7 @@ function verifyProfile(profile: Profile) {
     curStack.push(node.frame.key)
   }
 
-  function closeFrame(value: number) {
+  function closeFrame(node: CallTreeNode, value: number) {
     if (lastValue != value) {
       stackList.push(curStack.map(k => `${k}`).join(';'))
       lastValue = value

--- a/profile.test.ts
+++ b/profile.test.ts
@@ -29,8 +29,8 @@ function verifyProfile(profile: Profile) {
 
   let stackList: string[] = []
   const curStack: (number | string)[] = []
-
   let lastValue = 0
+
   function openFrame(node: CallTreeNode, value: number) {
     if (lastValue != value) {
       stackList.push(curStack.map(k => `${k}`).join(';'))
@@ -62,13 +62,43 @@ function verifyProfile(profile: Profile) {
     'a',
   ])
 
+  lastValue = 0
   stackList = []
   profile.forEachCallGrouped(openFrame, closeFrame)
   expect(stackList).toEqual([
     // prettier-ignore
-    '',
     'a;b;e',
     'a;b;b',
+    'a;b;c',
+    'a;b;d',
+    'a;b',
+    'a',
+  ])
+
+  const flattened = profile.flattenRecursion()
+
+  lastValue = 0
+  stackList = []
+  flattened.forEachCall(openFrame, closeFrame)
+  expect(stackList).toEqual([
+    // prettier-ignore
+    'a',
+    'a;b',
+    'a;b;d',
+    'a;b;c',
+    '',
+    'a',
+    'a;b',
+    'a;b;e',
+    'a',
+  ])
+
+  lastValue = 0
+  stackList = []
+  flattened.forEachCallGrouped(openFrame, closeFrame)
+  expect(stackList).toEqual([
+    // prettier-ignore
+    'a;b;e',
     'a;b;c',
     'a;b;d',
     'a;b',

--- a/row-atlas.ts
+++ b/row-atlas.ts
@@ -1,0 +1,94 @@
+import regl from 'regl'
+import {LRUCache} from './lru-cache'
+import {RectangleBatch} from './rectangle-batch-renderer'
+import {CanvasContext} from './canvas-context'
+import {Rect, Vec2} from './math'
+import {Color} from './color'
+
+export class RowAtlas<K> {
+  texture: regl.Texture
+  private framebuffer: regl.Framebuffer
+  private renderToFramebuffer: regl.Command<{}>
+  private rowCache: LRUCache<K, number>
+  private clearLineBatch: RectangleBatch
+
+  constructor(private canvasContext: CanvasContext) {
+    this.texture = canvasContext.gl.texture({
+      width: Math.min(canvasContext.getMaxTextureSize(), 4096),
+      height: Math.min(canvasContext.getMaxTextureSize(), 1024),
+      wrapS: 'clamp',
+      wrapT: 'clamp',
+    })
+    this.framebuffer = canvasContext.gl.framebuffer({color: [this.texture]})
+    this.rowCache = new LRUCache(this.texture.height)
+    this.renderToFramebuffer = canvasContext.gl({
+      framebuffer: this.framebuffer,
+    })
+    this.clearLineBatch = canvasContext.createRectangleBatch()
+    this.clearLineBatch.addRect(Rect.unit, new Color(0, 0, 0, 0))
+  }
+
+  has(key: K) {
+    return this.rowCache.has(key)
+  }
+  getResolution() {
+    return this.texture.width
+  }
+  getCapacity() {
+    return this.texture.height
+  }
+
+  private allocateLine(key: K): number {
+    if (this.rowCache.getSize() < this.rowCache.getCapacity()) {
+      // Not in cache, but cache isn't full
+      const row = this.rowCache.getSize()
+      this.rowCache.insert(key, row)
+      return row
+    } else {
+      // Not in cache, and cache is full. Evict something.
+      const [, row] = this.rowCache.removeLRU()!
+      this.rowCache.insert(key, row)
+      return row
+    }
+  }
+
+  writeToAtlasIfNeeded(keys: K[], render: (textureDstRect: Rect, key: K) => void) {
+    this.renderToFramebuffer((context: regl.Context) => {
+      for (let key of keys) {
+        let row = this.rowCache.get(key)
+        if (row != null) {
+          // Already cached!
+          continue
+        }
+        // Not cached -- we'll have to actually render
+        row = this.allocateLine(key)
+
+        const textureRect = new Rect(new Vec2(0, row), new Vec2(this.texture.width, 1))
+        this.canvasContext.drawRectangleBatch({
+          batch: this.clearLineBatch,
+          configSpaceSrcRect: Rect.unit,
+          physicalSpaceDstRect: textureRect,
+        })
+        render(textureRect, key)
+      }
+    })
+  }
+
+  renderViaAtlas(key: K, dstRect: Rect): boolean {
+    let row = this.rowCache.get(key)
+    if (row == null) {
+      return false
+    }
+
+    const textureRect = new Rect(new Vec2(0, row), new Vec2(this.texture.width, 1))
+
+    // At this point, we have the row in cache, and we can
+    // paint directly from it into the framebuffer.
+    this.canvasContext.drawTexture({
+      texture: this.texture,
+      srcRect: textureRect,
+      dstRect: dstRect,
+    })
+    return true
+  }
+}

--- a/row-atlas.ts
+++ b/row-atlas.ts
@@ -15,7 +15,7 @@ export class RowAtlas<K> {
   constructor(private canvasContext: CanvasContext) {
     this.texture = canvasContext.gl.texture({
       width: Math.min(canvasContext.getMaxTextureSize(), 4096),
-      height: Math.min(canvasContext.getMaxTextureSize(), 1024),
+      height: Math.min(canvasContext.getMaxTextureSize(), 4096),
       wrapS: 'clamp',
       wrapT: 'clamp',
     })

--- a/sample/profiles/stackcollapse/recursion.txt
+++ b/sample/profiles/stackcollapse/recursion.txt
@@ -1,0 +1,10 @@
+a;a 1
+b;b 1
+a;b 1
+a;b;a;b 1
+a;b;a;c 1
+a;b;a;b;a;b 1
+a;b;a;b;c 1
+a;b;a;b 1
+a;b;a;c 1
+a;b;a;b;c 1

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -30,7 +30,7 @@ export function dumpProfile(profile: Profile): any {
     curStack.push(node.frame.name)
   }
 
-  function closeFrame(value: number) {
+  function closeFrame(node: CallTreeNode, value: number) {
     maybeEmit(value)
     curStack.pop()
   }

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -8,6 +8,7 @@ import {
   itReduce,
   zeroPad,
   formatPercent,
+  KeyedSet,
 } from './utils'
 
 test('sortBy', () => {
@@ -23,6 +24,31 @@ test('getOrInsert', () => {
   expect(getOrInsert(m, 'x', k => k.length)).toBe(1)
   expect(m.get('hello')).toBe(5)
   expect(m.get('x')).toBe(1)
+})
+
+class ValueType {
+  private constructor(readonly a: string, readonly num: number) {}
+  get key() {
+    return `${this.a}_${this.num}`
+  }
+  static getOrInsert(set: KeyedSet<ValueType>, a: string, num: number) {
+    return set.getOrInsert(new ValueType(a, num))
+  }
+}
+
+test('KeyedSet', () => {
+  const set = new KeyedSet<ValueType>()
+
+  const x1 = ValueType.getOrInsert(set, 'x', 1)
+  const x2 = ValueType.getOrInsert(set, 'x', 1)
+  const y = ValueType.getOrInsert(set, 'y', 1)
+
+  expect(x1).toBe(x2)
+  expect(y).not.toBe(x1)
+
+  const set2 = new KeyedSet<ValueType>()
+  const x3 = ValueType.getOrInsert(set2, 'x', 1)
+  expect(x1).not.toBe(x3)
 })
 
 test('getOrElse', () => {


### PR DESCRIPTION
This makes the left-heavy view much more useful since recursive calls are all collapsed together.

Press `r` to activate

Fixes #37