### PR TITLE
Make speedscope work when hosted on an arbitrary URL or served from file://

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -22,7 +22,7 @@ date > "$OUTDIR"/release.txt
 git rev-parse HEAD >> "$OUTDIR"/release.txt
 
 # Build the compiled assets
-node_modules/.bin/parcel build index.html --out-dir "$OUTDIR" --public-url / --detailed-report
+node_modules/.bin/parcel build index.html --no-cache --out-dir "$OUTDIR" --public-url "./" --detailed-report
 
 # Create a shallow clone of the repository
 TMPDIR=`mktemp -d -t speedscope-release`

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,6 +24,12 @@ git rev-parse HEAD >> "$OUTDIR"/release.txt
 # Build the compiled assets
 node_modules/.bin/parcel build index.html --no-cache --out-dir "$OUTDIR" --public-url "./" --detailed-report
 
+# Create an archive with the release contents in it
+pushd "$OUTDIR"
+rm -rf ../release.zip
+zip -r ../release.zip .
+popd
+
 # Create a shallow clone of the repository
 TMPDIR=`mktemp -d -t speedscope-release`
 echo "Entering $TMPDIR"


### PR DESCRIPTION
This makes it easier to download speedscope to run totally offline, and makes embedding it into other applications easier since it no longer depends on specific URL paths.