### PR TITLE
Add tests ensuring that import still works even for unfamiliar filenames

### DIFF
--- a/test-utils.ts
+++ b/test-utils.ts
@@ -55,6 +55,15 @@ export async function checkProfileSnapshot(filepath: string) {
     return
   }
 
+  const profileWithoutFilename = await importProfile('unknown', input)
+  if (profileWithoutFilename) {
+    profileWithoutFilename.setName(profile.getName())
+    expect(exportProfile(profileWithoutFilename)).toEqual(exportProfile(profile))
+  } else {
+    fail('Failed to extract profile when filename was "unknown"')
+    return
+  }
+
   const exported = exportProfile(profile)
   const reimported = importSpeedscopeProfiles(exported)[0]
 


### PR DESCRIPTION
When importing files, there are two different paths we use for determining the file format.

The first is to pattern match on the filename.

If that fails, we fall back to examining the structure of the file, which can be slower and therefore wasteful.

Before this PR, we only tests that the filename pattern matching was correctly identifying the format. This PR ensures that our file structure matching is working correctly too.