### PR TITLE
Clamp zoom to prevent floating point issues

### DIFF
--- a/src/views/flamechart-view.tsx
+++ b/src/views/flamechart-view.tsx
@@ -3,7 +3,7 @@ import {css} from 'aphrodite'
 
 import {CallTreeNode} from '../lib/profile'
 
-import {Rect, Vec2, AffineTransform, clamp} from '../lib/math'
+import {Rect, Vec2, AffineTransform} from '../lib/math'
 import {formatPercent} from '../lib/utils'
 import {FlamechartMinimapView} from './flamechart-minimap-view'
 
@@ -29,12 +29,7 @@ export class FlamechartView extends StatelessComponent<FlamechartViewProps> {
 
     const configSpaceSize = this.configSpaceSize()
 
-    const width = clamp(
-      viewportRect.size.x,
-      Math.min(configSpaceSize.x, 3 * this.props.flamechart.getMinFrameWidth()),
-      configSpaceSize.x,
-    )
-
+    const width = this.props.flamechart.getClampedViewportWidth(viewportRect.size.x)
     const size = viewportRect.size.withX(width)
 
     const origin = Vec2.clamp(

--- a/src/views/flamechart-wrapper.tsx
+++ b/src/views/flamechart-wrapper.tsx
@@ -2,7 +2,7 @@ import {CallTreeNode} from '../lib/profile'
 import {StyleSheet, css} from 'aphrodite'
 import {h} from 'preact'
 import {commonStyle, Colors} from './style'
-import {Rect, AffineTransform, Vec2, clamp} from '../lib/math'
+import {Rect, AffineTransform, Vec2} from '../lib/math'
 import {FlamechartPanZoomView} from './flamechart-pan-zoom-view'
 import {noop, formatPercent} from '../lib/utils'
 import {Hovertip} from './hovertip'
@@ -14,11 +14,7 @@ export class FlamechartWrapper extends StatelessComponent<FlamechartViewProps> {
   private clampViewportToFlamegraph(viewportRect: Rect) {
     const {flamechart, renderInverted} = this.props
     const configSpaceSize = new Vec2(flamechart.getTotalWeight(), flamechart.getLayers().length)
-    const width = clamp(
-      viewportRect.size.x,
-      Math.min(configSpaceSize.x, 3 * flamechart.getMinFrameWidth()),
-      configSpaceSize.x,
-    )
+    const width = this.props.flamechart.getClampedViewportWidth(viewportRect.size.x)
     const size = viewportRect.size.withX(width)
     const origin = Vec2.clamp(
       viewportRect.origin,


### PR DESCRIPTION
Test Plan:

Copy and paste the following into speedscope, then zoom in as far as you can into the right side of the profile.

```
a 1
b 100000000000000000000
```

Before this PR, it would hang. After this PR, it caps the zoom and doesn't hang. The cap of the zoom still allows you to zoom in really, really far.

Fixed #61