### PR TITLE
Support emscripten symbols containing dashes

### DIFF
--- a/src/lib/emscripten.test.ts
+++ b/src/lib/emscripten.test.ts
@@ -21,10 +21,11 @@ test('importEmscriptenSymbolMap', () => {
         'a:A',
         'b:B',
         'c:C',
+        'd:D-D',
         '',
       ].join('\n'),
     ),
-  ).toEqual(new Map([['a', 'A'], ['b', 'B'], ['c', 'C']]))
+  ).toEqual(new Map([['a', 'A'], ['b', 'B'], ['c', 'C'], ['d', 'D-D']]))
 
   // Valid symbol map with non-alpha characters
   expect(importEmscriptenSymbolMap('u6:__ZN8tinyxml210XMLCommentD0Ev\n')).toEqual(
@@ -39,10 +40,16 @@ test('importEmscriptenSymbolMap', () => {
         '0:A',
         '1:B',
         '2:C',
+        '3:D-D',
       ].join('\n'),
     ),
   ).toEqual(
-    new Map([['wasm-function[0]', 'A'], ['wasm-function[1]', 'B'], ['wasm-function[2]', 'C']]),
+    new Map([
+      ['wasm-function[0]', 'A'],
+      ['wasm-function[1]', 'B'],
+      ['wasm-function[2]', 'C'],
+      ['wasm-function[3]', 'D-D'],
+    ]),
   )
 
   // Invalid symbol map

--- a/src/lib/emscripten.ts
+++ b/src/lib/emscripten.ts
@@ -14,8 +14,8 @@ export function importEmscriptenSymbolMap(contents: string): EmscriptenSymbolMap
   if (!lines.length) return null
 
   const map: EmscriptenSymbolMap = new Map()
-  const intRegex = /^(\d+):([\$\w]+)$/
-  const idRegex = /^([\$\w]+):([\$\w]+)$/
+  const intRegex = /^(\d+):([\$\w-]+)$/
+  const idRegex = /^([\$\w]+):([\$\w-]+)$/
 
   for (const line of lines) {
     // Match lines like "103:__ZN8tinyxml210XMLCommentD0Ev"
@@ -31,6 +31,8 @@ export function importEmscriptenSymbolMap(contents: string): EmscriptenSymbolMap
       map.set(idMatch[1], idMatch[2])
       continue
     }
+
+    console.log('Unmatched line', line)
 
     return null
   }

--- a/src/lib/emscripten.ts
+++ b/src/lib/emscripten.ts
@@ -32,8 +32,6 @@ export function importEmscriptenSymbolMap(contents: string): EmscriptenSymbolMap
       continue
     }
 
-    console.log('Unmatched line', line)
-
     return null
   }
 


### PR DESCRIPTION
Apparently emscripten symbols are allowed to contain dashes?

e.g. here's a line from a mapping that failed to import before this PR: `527:i32s-div`