### PR TITLE
Fix text culling of ellipses along the left side of the viewport

### DIFF
--- a/src/views/flamechart-pan-zoom-view.tsx
+++ b/src/views/flamechart-pan-zoom-view.tsx
@@ -227,22 +227,24 @@ export class FlamechartPanZoomView extends Component<FlamechartPanZoomViewProps,
           )
         }
 
-        const trimmedText = trimTextMid(
-          ctx,
-          frame.node.frame.name,
-          physicalLabelBounds.width() - 2 * LABEL_PADDING_PX,
-        )
+        if (physicalLabelBounds.width() > minWidthToRender) {
+          const trimmedText = trimTextMid(
+            ctx,
+            frame.node.frame.name,
+            physicalLabelBounds.width() - 2 * LABEL_PADDING_PX,
+          )
 
-        // Note that this is specifying the position of the starting text
-        // baseline.
-        ctx.fillText(
-          trimmedText,
-          physicalLabelBounds.left() + LABEL_PADDING_PX,
-          Math.round(
-            physicalLabelBounds.bottom() -
-              (physicalViewSpaceFrameHeight - physicalViewSpaceFontSize) / 2,
-          ),
-        )
+          // Note that this is specifying the position of the starting text
+          // baseline.
+          ctx.fillText(
+            trimmedText,
+            physicalLabelBounds.left() + LABEL_PADDING_PX,
+            Math.round(
+              physicalLabelBounds.bottom() -
+                (physicalViewSpaceFrameHeight - physicalViewSpaceFontSize) / 2,
+            ),
+          )
+        }
       }
       for (let child of frame.children) {
         renderFrameLabelAndChildren(child, depth + 1)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/150329/44312631-2c716280-a3b0-11e8-8834-2574b3a4a627.png)

After:
![image](https://user-images.githubusercontent.com/150329/44312639-48750400-a3b0-11e8-8017-41640fe56a22.png)

Fixes #134
