### PR TITLE
Change time formatting for minutes from 1.50min to 1:30

### DIFF
--- a/src/lib/value-formatters.test.ts
+++ b/src/lib/value-formatters.test.ts
@@ -7,7 +7,8 @@ describe('TimeFormatter', () => {
     expect(f.format(0.04)).toEqual('40.00µs')
     expect(f.format(3)).toEqual('3.00ms')
     expect(f.format(2070)).toEqual('2.07s')
-    expect(f.format(1203123)).toEqual('20.05min')
+    expect(f.format(150000)).toEqual('2:30')
+    expect(f.format(1203123)).toEqual('20:03')
   })
 
   test('input units seconds', () => {
@@ -15,7 +16,8 @@ describe('TimeFormatter', () => {
     expect(f.format(0.00004)).toEqual('40.00µs')
     expect(f.format(0.003)).toEqual('3.00ms')
     expect(f.format(2.07)).toEqual('2.07s')
-    expect(f.format(1203.123)).toEqual('20.05min')
+    expect(f.format(150)).toEqual('2:30')
+    expect(f.format(1203.123)).toEqual('20:03')
   })
 })
 

--- a/src/lib/value-formatters.ts
+++ b/src/lib/value-formatters.ts
@@ -1,4 +1,5 @@
 import {FileFormat} from './file-format-spec'
+import {zeroPad} from './utils'
 
 export interface ValueFormatter {
   unit: FileFormat.ValueUnit
@@ -25,7 +26,11 @@ export class TimeFormatter implements ValueFormatter {
   formatUnsigned(v: number) {
     const s = v * this.multiplier
 
-    if (s / 60 >= 1) return `${(s / 60).toFixed(2)}min`
+    if (s / 60 >= 1) {
+      const minutes = Math.floor(s / 60)
+      const seconds = Math.floor(s - minutes * 60).toString()
+      return `${minutes}:${zeroPad(seconds, 2)}`
+    }
     if (s / 1 >= 1) return `${s.toFixed(2)}s`
     if (s / 1e-3 >= 1) return `${(s / 1e-3).toFixed(2)}ms`
     if (s / 1e-6 >= 1) return `${(s / 1e-6).toFixed(2)}µs`


### PR DESCRIPTION
Hi @jlfwong, I made changes to `TimeFormatter` to fix #90. Now it should render `1:30min` instead of `1.50min` 

However, I am not very proficient in Typescript and I did an ugly workaround. Maybe you can suggest something more elegant?