### PR TITLE
Allow optional CR before LF when probing collapsed stacks files

### DIFF
--- a/sample/profiles/stackcollapse/simple-crlf.txt
+++ b/sample/profiles/stackcollapse/simple-crlf.txt
@@ -1,0 +1,5 @@
+a;b;c 1
+a;b;c 1
+a;b;d 4
+a;b;c 3
+a;b 5

--- a/src/import/__snapshots__/bg-flamegraph.test.ts.snap
+++ b/src/import/__snapshots__/bg-flamegraph.test.ts.snap
@@ -53,3 +53,57 @@ Object {
 exports[`importFromBGFlameGraph: indexToView 1`] = `0`;
 
 exports[`importFromBGFlameGraph: profileGroup.name 1`] = `"simple.txt"`;
+
+exports[`importFromBGFlameGraphWithCRLF 1`] = `
+Object {
+  "frames": Array [
+    Frame {
+      "col": undefined,
+      "file": undefined,
+      "key": "a",
+      "line": undefined,
+      "name": "a",
+      "selfWeight": 0,
+      "totalWeight": 14,
+    },
+    Frame {
+      "col": undefined,
+      "file": undefined,
+      "key": "b",
+      "line": undefined,
+      "name": "b",
+      "selfWeight": 5,
+      "totalWeight": 14,
+    },
+    Frame {
+      "col": undefined,
+      "file": undefined,
+      "key": "c",
+      "line": undefined,
+      "name": "c",
+      "selfWeight": 5,
+      "totalWeight": 5,
+    },
+    Frame {
+      "col": undefined,
+      "file": undefined,
+      "key": "d",
+      "line": undefined,
+      "name": "d",
+      "selfWeight": 4,
+      "totalWeight": 4,
+    },
+  ],
+  "name": "simple-crlf.txt",
+  "stacks": Array [
+    "a;b;c 2",
+    "a;b;d 4",
+    "a;b;c 3",
+    "a;b 5",
+  ],
+}
+`;
+
+exports[`importFromBGFlameGraphWithCRLF: indexToView 1`] = `0`;
+
+exports[`importFromBGFlameGraphWithCRLF: profileGroup.name 1`] = `"simple-crlf.txt"`;

--- a/src/import/__snapshots__/bg-flamegraph.test.ts.snap
+++ b/src/import/__snapshots__/bg-flamegraph.test.ts.snap
@@ -50,11 +50,7 @@ Object {
 }
 `;
 
-exports[`importFromBGFlameGraph: indexToView 1`] = `0`;
-
-exports[`importFromBGFlameGraph: profileGroup.name 1`] = `"simple.txt"`;
-
-exports[`importFromBGFlameGraphWithCRLF 1`] = `
+exports[`importFromBGFlameGraph with CRLF 1`] = `
 Object {
   "frames": Array [
     Frame {
@@ -104,6 +100,10 @@ Object {
 }
 `;
 
-exports[`importFromBGFlameGraphWithCRLF: indexToView 1`] = `0`;
+exports[`importFromBGFlameGraph with CRLF: indexToView 1`] = `0`;
 
-exports[`importFromBGFlameGraphWithCRLF: profileGroup.name 1`] = `"simple-crlf.txt"`;
+exports[`importFromBGFlameGraph with CRLF: profileGroup.name 1`] = `"simple-crlf.txt"`;
+
+exports[`importFromBGFlameGraph: indexToView 1`] = `0`;
+
+exports[`importFromBGFlameGraph: profileGroup.name 1`] = `"simple.txt"`;

--- a/src/import/bg-flamegraph.test.ts
+++ b/src/import/bg-flamegraph.test.ts
@@ -3,3 +3,7 @@ import {checkProfileSnapshot} from '../lib/test-utils'
 test('importFromBGFlameGraph', async () => {
   await checkProfileSnapshot('./sample/profiles/stackcollapse/simple.txt')
 })
+
+test('importFromBGFlameGraphWithCRLF', async () => {
+  await checkProfileSnapshot('./sample/profiles/stackcollapse/simple-crlf.txt')
+})

--- a/src/import/bg-flamegraph.test.ts
+++ b/src/import/bg-flamegraph.test.ts
@@ -4,6 +4,6 @@ test('importFromBGFlameGraph', async () => {
   await checkProfileSnapshot('./sample/profiles/stackcollapse/simple.txt')
 })
 
-test('importFromBGFlameGraphWithCRLF', async () => {
+test('importFromBGFlameGraph with CRLF', async () => {
   await checkProfileSnapshot('./sample/profiles/stackcollapse/simple-crlf.txt')
 })

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -103,7 +103,7 @@ async function _importProfileGroup(
     // If every line ends with a space followed by a number, it's probably
     // the collapsed stack format.
     const lineCount = contents.split(/\n/).length
-    if (lineCount >= 1 && lineCount === contents.split(/ \d+\n/).length) {
+    if (lineCount >= 1 && lineCount === contents.split(/ \d+\r?\n/).length) {
       console.log('Importing as collapsed stack format')
       return toGroup(importFromBGFlameGraph(contents))
     }


### PR DESCRIPTION
This fixes #152, in that it allows "collapsed stacks" files generated with
tools using Windows line endings to be imported into the tool verbatim.