### PR TITLE
Fix import from Chrome 68 when there are multiple profiles

### DIFF
--- a/src/import/chrome.ts
+++ b/src/import/chrome.ts
@@ -74,7 +74,6 @@ export function importFromChromeTimeline(events: TimelineEvent[]): Profile {
   for (let event of events) {
     if (event.name == 'CpuProfile') {
       cpuProfile = event.args.data.cpuProfile as CPUProfile
-      break
     }
 
     if (event.name == 'Profile') {


### PR DESCRIPTION
It seems like #160 accidentally broken import of profiles in some circumstances from Chrome 68. Before #160, we always took the first profile in the list *but* the profiles were not sorted chronologically. After #160 but before this PR, we were taking the chronologically first.

After this PR, we always take the chronologically last `CpuProfile` event in the trace.