### PR TITLE
add base64 support to HashParams

### DIFF
--- a/src/lib/hash-params.test.ts
+++ b/src/lib/hash-params.test.ts
@@ -24,4 +24,7 @@ test('getHashParams', () => {
   })
   expect(getHashParams('#abc=bcd')).toEqual({})
   expect(getHashParams('garbage')).toEqual({})
+  expect(getHashParams('#profileBase64URL=aHR0cDovL3Rlc3QuY29tL3Byb2ZpbGU/dGVzdD10ZXN0')).toEqual({
+    profileURL: 'http://test.com/profile?test=test',
+  })
 })

--- a/src/lib/hash-params.ts
+++ b/src/lib/hash-params.ts
@@ -2,6 +2,7 @@ export interface HashParams {
   profileURL?: string
   title?: string
   localProfilePath?: string
+  profileBase64URL?: string
 }
 
 export function getHashParams(hashContents = window.location.hash): HashParams {
@@ -20,6 +21,8 @@ export function getHashParams(hashContents = window.location.hash): HashParams {
         result.title = value
       } else if (key === 'localProfilePath') {
         result.localProfilePath = value
+      } else if (key === 'profileBase64URL') {
+        result.profileURL = atob(value)
       }
     }
     return result


### PR DESCRIPTION
Hello,

For pm2.io we want to be able to open one of our profiling from the app. For that, speedscope need to handle hash parameters in `#profileURL`. To not break compatibility we just added another hash paramater: `#profileBase64URL` like that you can give an url with query parameters without it being parsed by chrome.

Thanks