### PR TITLE
Make the wasd keymappings work on azerty keyboards

### DIFF
--- a/src/views/flamechart-pan-zoom-view.tsx
+++ b/src/views/flamechart-pan-zoom-view.tsx
@@ -662,13 +662,13 @@ export class FlamechartPanZoomView extends Component<FlamechartPanZoomViewProps,
 
     if (ev.key === '0') {
       this.zoom(new Vec2(width / 2, height / 2), 1e9)
-    } else if (ev.key === 'ArrowRight' || ev.key === 'd') {
+    } else if (ev.key === 'ArrowRight' || ev.code === 'KeyD') {
       this.pan(new Vec2(100, 0))
-    } else if (ev.key === 'ArrowLeft' || ev.key === 'a') {
+    } else if (ev.key === 'ArrowLeft' || ev.code === 'KeyA') {
       this.pan(new Vec2(-100, 0))
-    } else if (ev.key === 'ArrowUp' || ev.key === 'w') {
+    } else if (ev.key === 'ArrowUp' || ev.code === 'KeyW') {
       this.pan(new Vec2(0, -100))
-    } else if (ev.key === 'ArrowDown' || ev.key === 's') {
+    } else if (ev.key === 'ArrowDown' || ev.code === 'KeyS') {
       this.pan(new Vec2(0, 100))
     } else if (ev.key === 'Escape') {
       this.props.onNodeSelect(null)


### PR DESCRIPTION
Instead of using `key`, use `code` which according to [this](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) should work consistently for different layouts.

I tested the modification on a french AZERTY keyboard and it works fine.