### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
-  - '9'
+  - 'node'
+  - '10'
+  - '8'
+  - '6'
+install: npm install


### PR DESCRIPTION
Node.js 6, 8 and 10 are current LTS branches. 11 is stable (`node`). 9 already reached its EOL. See https://github.com/nodejs/Release/blob/master/README.md