### PR TITLE
Fix import of multithreaded Chrome profiles

### DIFF
--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -89,7 +89,7 @@ async function _importProfileGroup(dataSource: ProfileDataSource): Promise<Profi
     return toGroup(importFromChromeCPUProfile(JSON.parse(contents)))
   } else if (fileName.endsWith('.chrome.json') || /Profile-\d{8}T\d{6}/.exec(fileName)) {
     console.log('Importing as Chrome Timeline')
-    return toGroup(importFromChromeTimeline(JSON.parse(contents)))
+    return importFromChromeTimeline(JSON.parse(contents), fileName)
   } else if (fileName.endsWith('.stackprof.json')) {
     console.log('Importing as stackprof profile')
     return toGroup(importFromStackprof(JSON.parse(contents)))
@@ -124,7 +124,7 @@ async function _importProfileGroup(dataSource: ProfileDataSource): Promise<Profi
       return toGroup(importFromFirefox(parsed))
     } else if (isChromeTimeline(parsed)) {
       console.log('Importing as Chrome CPU Profile')
-      return toGroup(importFromChromeTimeline(parsed))
+      return importFromChromeTimeline(parsed, fileName)
     } else if ('nodes' in parsed && 'samples' in parsed && 'timeDeltas' in parsed) {
       console.log('Importing as Chrome Timeline')
       return toGroup(importFromChromeCPUProfile(parsed))


### PR DESCRIPTION
In #160, I wrote code which incorrectly assumed that at most one profile would be active at a time. It turns out this assumption is incorrect because of webworkers! This PR introduces a fix which correctly separates samples taken on the main thread from samples taken on worker threads, and allows viewing both in speedscope.

Fixes #171