### PR TITLE
Fix importing of Trace Event Format files with no ts field on M events

### DIFF
--- a/sample/profiles/trace-event/multiprocess.json
+++ b/sample/profiles/trace-event/multiprocess.json
@@ -1,22 +1,22 @@
 [
-  {"pid": 0, "tid": 0, "ph": "M", "name": "process_name", "args": {"name": "p0"}, "ts": 0},
-  {"pid": 0, "tid": 0, "ph": "M", "name": "thread_name", "args": {"name": "p0t0"}, "ts": 0},
+  {"pid": 0, "tid": 0, "ph": "M", "name": "process_name", "args": {"name": "p0"}},
+  {"pid": 0, "tid": 0, "ph": "M", "name": "thread_name", "args": {"name": "p0t0"}},
   {"pid": 0, "tid": 0, "ph": "X", "name": "alpha", "ts": 0, "dur": 1},
-  {"pid": 0, "tid": 1, "ph": "M", "name": "thread_name", "args": {"name": "p0t1"}, "ts": 0},
+  {"pid": 0, "tid": 1, "ph": "M", "name": "thread_name", "args": {"name": "p0t1"}},
   {"pid": 0, "tid": 1, "ph": "X", "name": "beta", "ts": 0, "dur": 1},
 
-  {"pid": 1, "tid": 0, "ph": "M", "name": "process_name", "args": {"name": "p1"}, "ts": 0},
-  {"pid": 1, "tid": 0, "ph": "M", "name": "thread_name", "args": {"name": "p1t0"}, "ts": 0},
+  {"pid": 1, "tid": 0, "ph": "M", "name": "process_name", "args": {"name": "p1"}},
+  {"pid": 1, "tid": 0, "ph": "M", "name": "thread_name", "args": {"name": "p1t0"}},
   {"pid": 1, "tid": 0, "ph": "X", "name": "gamma", "ts": 0, "dur": 1},
-  {"pid": 1, "tid": 1, "ph": "M", "name": "thread_name", "args": {"name": "p1t1"}, "ts": 0},
+  {"pid": 1, "tid": 1, "ph": "M", "name": "thread_name", "args": {"name": "p1t1"}},
   {"pid": 1, "tid": 1, "ph": "X", "name": "delta", "ts": 0, "dur": 1},
 
-  {"pid": 2, "tid": 0, "ph": "M", "name": "thread_name", "args": {"name": "p2t0"}, "ts": 0},
+  {"pid": 2, "tid": 0, "ph": "M", "name": "thread_name", "args": {"name": "p2t0"}},
   {"pid": 2, "tid": 0, "ph": "X", "name": "epsilon", "ts": 0, "dur": 1},
-  {"pid": 2, "tid": 1, "ph": "M", "name": "thread_name", "args": {"name": "p2t1"}, "ts": 0},
+  {"pid": 2, "tid": 1, "ph": "M", "name": "thread_name", "args": {"name": "p2t1"}},
   {"pid": 2, "tid": 1, "ph": "X", "name": "phi", "ts": 0, "dur": 1},
 
-  {"pid": 3, "tid": 0, "ph": "M", "name": "process_name", "args": {"name": "p3"}, "ts": 0},
+  {"pid": 3, "tid": 0, "ph": "M", "name": "process_name", "args": {"name": "p3"}},
   {"pid": 3, "tid": 0, "ph": "X", "name": "zeta", "ts": 0, "dur": 1},
   {"pid": 3, "tid": 1, "ph": "X", "name": "eta", "ts": 0, "dur": 1}
 ]

--- a/src/import/trace-event.ts
+++ b/src/import/trace-event.ts
@@ -251,7 +251,25 @@ function isTraceEventList(maybeEventList: any): maybeEventList is TraceEvent[] {
   // fields are mandatory, but without these fields, we won't usefully be able
   // to import the data, so we'll rely upon these.
   for (let el of maybeEventList) {
-    if (!('ph' in el) || !('ts' in el)) return false
+    if (!('ph' in el)) {
+      return false
+    }
+
+    switch (el.ph) {
+      case 'B':
+      case 'E':
+      case 'X':
+        // All B, E, and X events must have a timestamp specified, otherwise we
+        // won't be able to import correctly.
+        if (!('ts' in el)) {
+          return false
+        }
+
+      case 'M':
+        // It's explicitly okay for "M" (metadata) events not to specify a "ts"
+        // field, since usually there is no logical timestamp for them to have
+        break
+    }
   }
 
   return true


### PR DESCRIPTION
The spec for the Trace Event Format technically requires that all entries have "ts" values, and they do in the profiles recorded using chrome://tracing. We don't actually use those values in the case of "M" (metadata) events, however, and they're semantically meaningless as far as I can tell, so let's stop requiring them.

This allows the files that @aras-p provided in #77 to import successfully.

Fixes #77 
