### PR TITLE
keep the order of the events that have the same timestamp

### DIFF
--- a/src/import/trace-event.ts
+++ b/src/import/trace-event.ts
@@ -177,7 +177,7 @@ function eventListToProfileGroup(events: TraceEvent[]): ProfileGroup {
       }
     }
 
-    return -1
+    return 1
   })
 
   if (durationEvents.length > 0) {


### PR DESCRIPTION
fix import trace event error while the event have the same timestamp.
like this:
[
{"tid": 1, "ph": "B", "pid": 0, "name": "Looper:dispatch(Loope)", "ts": 0},
{"tid": 1, "ph": "B", "pid": 0, "name": "MainActivity:onCreate(com.bytedance.android.app)", "ts": 8},
{"tid": 1, "ph": "B", "pid": 0, "name": "MainActivity:sayHello2(com.bytedance.android.app)", "ts": 22},
{"tid": 1, "ph": "B", "pid": 0, "name": "Block:block(com.bytedance.android.app.trace)", "ts": 22},
{"tid": 1, "ph": "E", "pid": 0, "name": "Block:block(com.bytedance.android.app.trace)", "ts": 54},
{"tid": 1, "ph": "B", "pid": 0, "name": "Speaker:sayHello(com.bytedance.android.app)", "ts": 58},
{"tid": 1, "ph": "B", "pid": 0, "name": "Block:block(com.bytedance.android.app.trace)", "ts": 58},
{"tid": 1, "ph": "E", "pid": 0, "name": "Block:block(com.bytedance.android.app.trace)", "ts": 64},
{"tid": 1, "ph": "E", "pid": 0, "name": "Speaker:sayHello(com.bytedance.android.app)", "ts": 64},
{"tid": 1, "ph": "E", "pid": 0, "name": "MainActivity:sayHello2(com.bytedance.android.app)", "ts": 65},
{"tid": 1, "ph": "E", "pid": 0, "name": "MainActivity:onCreate(com.bytedance.android.app)", "ts": 65},
{"tid": 1, "ph": "E", "pid": 0, "name": "Looper:dispatch(Loope)", "ts": 74},
{"tid": 1, "ph": "B", "pid": 0, "name": "Choreographer:doFrame(Choreographe)", "ts": 74},
{"tid": 1, "ph": "B", "pid": 0, "name": "BlockTextView:draw(com.bytedance.android.app.trace)", "ts": 91},
{"tid": 1, "ph": "B", "pid": 0, "name": "BlockTextView:onDraw(com.bytedance.android.app.trace)", "ts": 92},
{"tid": 1, "ph": "B", "pid": 0, "name": "Block:block(com.bytedance.android.app.trace)", "ts": 92},
{"tid": 1, "ph": "E", "pid": 0, "name": "Block:block(com.bytedance.android.app.trace)", "ts": 128},
{"tid": 1, "ph": "E", "pid": 0, "name": "BlockTextView:onDraw(com.bytedance.android.app.trace)", "ts": 128},
{"tid": 1, "ph": "E", "pid": 0, "name": "BlockTextView:draw(com.bytedance.android.app.trace)", "ts": 132},
{"tid": 1, "ph": "E", "pid": 0, "name": "Choreographer:doFrame(Choreographe)", "ts": 146}
]