### PR TITLE
Fix hot module reload issues caused by subtle bug in useSelector

### DIFF
--- a/src/lib/preact-redux.tsx
+++ b/src/lib/preact-redux.tsx
@@ -57,7 +57,7 @@ export function useSelector<T, U>(selector: (t: T) => U): U {
     return store.subscribe(() => {
       setValue(getValueFromStore())
     })
-  }, [getValueFromStore])
+  }, [store, getValueFromStore])
 
   return value
 }

--- a/src/lib/preact-redux.tsx
+++ b/src/lib/preact-redux.tsx
@@ -45,13 +45,19 @@ export function useActionCreator<T, U>(creator: (payload: T) => Action<U>): (t: 
 
 export function useSelector<T, U>(selector: (t: T) => U): U {
   const store = useStore<T>()
-  const [value, setValue] = useState(() => selector(store.getState()))
+  const getValueFromStore = useCallback(() => selector(store.getState()), [store, selector])
+  const [value, setValue] = useState(getValueFromStore)
 
   useLayoutEffect(() => {
+    // We need to setValue here because it's possible something has changed the
+    // value in the store between the useSelector call and layout. In most cases
+    // this should no-op.
+    setValue(getValueFromStore())
+
     return store.subscribe(() => {
-      setValue(selector(store.getState()))
+      setValue(getValueFromStore())
     })
-  }, [store, selector])
+  }, [getValueFromStore])
 
   return value
 }


### PR DESCRIPTION
To test this, load a profile, then save a `.tsx` file locally. Before this change, it would bring you back to the welcome screen after hot reload. After this change, application state is still displayed. This is because before the change, the `setGLCanvas` action wasn't resulting in a re-render because it occurred between the initial render and the `useLayoutEffect` callback.

Fixes #276 