### PR TITLE
Introduce a profile selector dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Once a profile has loaded, the main view is split into two: the top area is the 
 * `Cmd+O`/`Ctrl+O` to open a new profile
 * `n`: Go to next profile/thread if one is available
 * `p`: Go to previous profile/thread if one is available
+* `t`: Open the profile/thread selector if available
 
 ## Contributing
 

--- a/src/lib/fuzzy-find.test.ts
+++ b/src/lib/fuzzy-find.test.ts
@@ -1,0 +1,81 @@
+import {fuzzyMatchStrings} from './fuzzy-find'
+import {sortBy} from './utils'
+
+function assertMatches(texts: string[], pattern: string, expectedResults: string[]) {
+  const results: {score: number; highlighted: string}[] = []
+
+  for (let text of texts) {
+    const match = fuzzyMatchStrings(text, pattern)
+    if (match == null) {
+      continue
+    }
+
+    let highlighted = ''
+    let last = 0
+    for (let range of match.matchedRanges) {
+      highlighted += `${text.slice(last, range[0])}[${text.slice(range[0], range[1])}]`
+      last = range[1]
+    }
+    highlighted += text.slice(last)
+
+    results.push({score: match.score, highlighted})
+  }
+
+  // Sort scores in descending order
+  sortBy(results, r => -r.score)
+  expect(results.map(r => r.highlighted)).toEqual(expectedResults)
+}
+
+function assertMatch(text: string, pattern: string, expected: string) {
+  assertMatches([text], pattern, [expected])
+}
+
+function assertNoMatch(text: string, pattern: string) {
+  assertMatches([text], pattern, [])
+}
+
+describe('fuzzyMatchStrings', () => {
+  test('no match', () => {
+    assertNoMatch('a', 'b')
+    assertNoMatch('aa', 'ab')
+    assertNoMatch('a', 'aa')
+    assertNoMatch('ca', 'ac')
+  })
+
+  test('full text match', () => {
+    assertMatch('hello', 'hello', '[hello]')
+    assertMatch('multiple words', 'multiple words', '[multiple words]')
+  })
+
+  test('case sensitivity', () => {
+    assertMatch('HELLO', 'hello', '[HELLO]')
+    assertMatch('Hello', 'hello', '[Hello]')
+    assertNoMatch('hello', 'Hello')
+    assertNoMatch('hello', 'HELLO')
+  })
+
+  test('multiple occurrences', () => {
+    assertMatch('hello hello', 'hello', '[hello] hello')
+    assertMatch('hellohello', 'hello', '[hello]hello')
+  })
+
+  test('prefer earlier matches', () => {
+    assertMatches(['cab', 'ab'], 'ab', ['[ab]', 'c[ab]'])
+  })
+
+  test('prefer shorter matches', () => {
+    assertMatches(['abbc', 'abc', 'abbbc'], 'ac', ['[a]b[c]', '[a]bb[c]', '[a]bbb[c]'])
+  })
+
+  test('prefer word boundaries', () => {
+    assertMatches(['abc', 'a c'], 'ac', ['[a] [c]', '[a]b[c]'])
+  })
+
+  test('prefer camelCase matches', () => {
+    assertMatches(['downtown', 'OutNode'], 'n', ['Out[N]ode', 'dow[n]town'])
+  })
+
+  test('prefer number prefix matches', () => {
+    assertMatches(['211', 'a123'], '1', ['a[1]23', '2[1]1'])
+  })
+})

--- a/src/lib/fuzzy-find.ts
+++ b/src/lib/fuzzy-find.ts
@@ -1,0 +1,246 @@
+/**
+ * This file contains an implementation of fuzzy string matching.
+ */
+
+export interface FuzzyMatch {
+  // List of [start, end] indices in the haystack string that match the needle string
+  matchedRanges: [number, number][]
+
+  // The score of the match for relative ranking. Higher scores indicate
+  // "better" matches.
+  score: number
+}
+
+export function fuzzyMatchStrings(text: string, pattern: string): FuzzyMatch | null {
+  return fzfFuzzyMatchV1(text, pattern)
+}
+
+// The implementation here is based on FuzzyMatchV1, as described here:
+// https://github.com/junegunn/fzf/blob/f81feb1e69e5cb75797d50817752ddfe4933cd68/src/algo/algo.go#L8-L15
+//
+// This is a hand-port to better understand what the code is doing and for added
+// clarity.
+//
+// Capitalized letters only match capitalized letters, but lower-case letters
+// match both.
+//
+// Note: fzf includes a normalization table for homoglyphs. I'm going to ignore that too
+// https://github.com/junegunn/fzf/blob/master/src/algo/normalize.go
+const charCodeLowerA = 'a'.charCodeAt(0)
+const charCodeLowerZ = 'z'.charCodeAt(0)
+const charCodeUpperA = 'A'.charCodeAt(0)
+const charCodeUpperZ = 'Z'.charCodeAt(0)
+const charCodeDigit0 = '0'.charCodeAt(0)
+const charCodeDigit9 = '9'.charCodeAt(0)
+
+enum fzfCharClass {
+  charNonWord,
+  charLower,
+  charUpper,
+  charNumber,
+}
+
+function fzfCharClassOf(char: string): fzfCharClass {
+  const code = char.charCodeAt(0)
+  if (charCodeLowerA <= code && code <= charCodeLowerZ) {
+    return fzfCharClass.charLower
+  } else if (charCodeUpperA <= code && code <= charCodeUpperZ) {
+    return fzfCharClass.charUpper
+  } else if (charCodeDigit0 <= code && code <= charCodeDigit9) {
+    return fzfCharClass.charNumber
+  }
+  return fzfCharClass.charNonWord
+}
+
+function charsMatch(textChar: string, patternChar: string): boolean {
+  if (textChar === patternChar) return true
+
+  const patternCharCode = patternChar.charCodeAt(0)
+  if (charCodeLowerA <= patternCharCode && patternCharCode <= charCodeLowerZ) {
+    return textChar.charCodeAt(0) === patternCharCode - charCodeLowerA + charCodeUpperA
+  }
+  return false
+}
+
+function fzfFuzzyMatchV1(text: string, pattern: string): FuzzyMatch | null {
+  if (pattern.length == 0) {
+    return {matchedRanges: [], score: 0}
+  }
+
+  // I removed the fzfAsciiFuzzyIndex code because it's not actually clear to
+  // me that it's a very helpful optimization.
+
+  let pidx = 0
+  let sidx = -1
+  let eidx = -1
+
+  let lenRunes = text.length
+  let lenPattern = pattern.length
+
+  // Forward pass: scan over the text pattern, identifying the earliest start
+  // and the latest end to consider.
+  for (let index = 0; index < lenRunes; index++) {
+    let char = text[index]
+    let pchar = pattern[pidx]
+    if (charsMatch(char, pchar)) {
+      if (sidx < 0) {
+        sidx = index
+      }
+      pidx++
+      if (pidx == lenPattern) {
+        // We found the last character in the pattern! eidx is exclusive, so
+        // we'll set it to the current index + 1.
+        eidx = index + 1
+        break
+      }
+    }
+  }
+
+  if (eidx == -1) {
+    // We couldn't find all the characters in the pattern. No match.
+    return null
+  }
+
+  // Assuming we found all the characters in the pattern, perform the backwards
+  // pass.
+  pidx--
+  for (let index = eidx - 1; index >= sidx; index--) {
+    const char = text[index]
+    const pchar = pattern[pidx]
+    if (charsMatch(char, pchar)) {
+      pidx--
+      if (pidx < 0) {
+        // We found the first character of the pattern, scanning
+        // backwards. This *may* have narrowed the match further.
+        // For example, for the following inputs:
+        //
+        //    text = "xxx a b c abc xxx"
+        // pattern = "abc"
+        //
+        // For the forward pass, you get:
+        //
+        //    "xxx a b c abc xxx"
+        //    start^        ^end
+        //
+        // But after the backward pass, we can narrow this to:
+        //
+        //    "xxx a b c abc xxx"
+        //          start^  ^end
+        sidx = index
+        return fzfCalculateScore(text, pattern, sidx, eidx)
+      }
+    }
+  }
+
+  // This should be unreachable.
+  throw new Error('Implementation error. This must be a bug in fzfFuzzyMatchV1')
+}
+
+const fzfScoreMatch = 16
+const fzfScoreGapStart = -3
+const fzfScoreGapExtension = -1
+const fzfBonusBoundary = fzfScoreMatch / 2
+const fzfBonusNonWord = fzfScoreMatch / 2
+const fzfBonusCamel123 = fzfBonusBoundary + fzfScoreGapExtension
+const fzfBonusConsecutive = -(fzfScoreGapStart + fzfScoreGapExtension)
+const fzfBonusFirstCharMultiplier = 2
+
+function bonusFor(prevClass: fzfCharClass, curClass: fzfCharClass): number {
+  if (prevClass === fzfCharClass.charNonWord && curClass !== fzfCharClass.charNonWord) {
+    // Prefer matching at word boundaries
+    //
+    // This should prefer "a c" over "abc" for a pattern of "ac".
+    return fzfBonusBoundary
+  }
+
+  if (
+    (prevClass === fzfCharClass.charLower && curClass == fzfCharClass.charUpper) ||
+    (prevClass !== fzfCharClass.charNumber && curClass == fzfCharClass.charNumber)
+  ) {
+    // Prefer matching at the transition point between lower & upper for camelCase,
+    // and from transition from letter to number for identifiers like letter123.
+    //
+    // This should prefer "OutNode" over "phone" for a pattern of "n",
+    // and "abc123" over "x211" for a pattern of "1".
+    return fzfBonusCamel123
+  }
+
+  if (curClass === fzfCharClass.charNonWord) {
+    return fzfBonusNonWord
+  }
+  return 0
+}
+
+function fzfCalculateScore(text: string, pattern: string, sidx: number, eidx: number): FuzzyMatch {
+  let pidx = 0
+  let score = 0
+  let inGap = false
+  let consecutive = 0
+  let firstBonus = 0
+  let pos: number[] = new Array(pattern.length)
+  let prevClass = fzfCharClass.charNonWord
+
+  if (sidx > 0) {
+    prevClass = fzfCharClassOf(text[sidx - 1])
+  }
+  for (let idx = sidx; idx < eidx; idx++) {
+    let char = text[idx]
+    let curClass = fzfCharClassOf(char)
+    if (charsMatch(char, pattern[pidx])) {
+      pos[pidx] = idx
+      score += fzfScoreMatch
+      let bonus = bonusFor(prevClass, curClass)
+      if (consecutive == 0) {
+        firstBonus = bonus
+      } else {
+        // Break consecutive chunk
+        if (bonus === fzfBonusBoundary) {
+          firstBonus = bonus
+        }
+        bonus = Math.max(bonus, firstBonus, fzfBonusConsecutive)
+      }
+      if (pidx === 0) {
+        score += bonus * fzfBonusFirstCharMultiplier
+      } else {
+        score += bonus
+      }
+      inGap = false
+      consecutive++
+      pidx++
+    } else {
+      if (inGap) {
+        // Penalize gaps (this bonus is negative)
+        score += fzfScoreGapExtension
+      } else {
+        // Penalize the beginning of gaps more harshly
+        score += fzfScoreGapStart
+      }
+      inGap = true
+      consecutive = 0
+      firstBonus = 0
+    }
+    prevClass = curClass
+  }
+
+  if (pidx !== pattern.length) {
+    throw new Error(
+      'fzfCalculateScore should only be called when pattern is found between sidx and eidx',
+    )
+  }
+
+  let matchedRanges: [number, number][] = [[pos[0], pos[0] + 1]]
+  for (let i = 1; i < pos.length; i++) {
+    const curPos = pos[i]
+    const curRange = matchedRanges[matchedRanges.length - 1]
+    if (curRange[1] === curPos) {
+      curRange[1] = curPos + 1
+    } else {
+      matchedRanges.push([curPos, curPos + 1])
+    }
+  }
+
+  return {
+    score,
+    matchedRanges,
+  }
+}

--- a/src/views/profile-select.tsx
+++ b/src/views/profile-select.tsx
@@ -253,7 +253,7 @@ export function ProfileSelect({
         setPendingForcedScroll(true)
       }
     },
-    [closeProfileSelect, setProfileIndexToView, hoveredProfileIndex],
+    [closeProfileSelect, setProfileIndexToView, hoveredProfileIndex, filteredProfiles],
   )
 
   const [pendingForcedScroll, setPendingForcedScroll] = useState(false)

--- a/src/views/profile-select.tsx
+++ b/src/views/profile-select.tsx
@@ -30,7 +30,7 @@ export function ProfileSelectRow({
 
   const scrollIntoView = useCallback(
     (node: HTMLElement | null) => {
-      if (node && selected) {
+      if (selectIsVisible && node && selected) {
         requestAnimationFrame(() => {
           node.scrollIntoView({
             behavior: 'auto',

--- a/src/views/profile-select.tsx
+++ b/src/views/profile-select.tsx
@@ -228,16 +228,6 @@ export function ProfileSelect({
               newHoveredIndexInFilteredList = indexInFilteredList - 1
             }
           }
-
-          let destIndex = filteredProfiles.length - 1
-          if (hoveredProfileIndex != null) {
-            const indexInFilteredList = filteredProfiles.findIndex(
-              p => p.indexInProfileGroup === hoveredProfileIndex,
-            )
-            if (indexInFilteredList >= 0 && indexInFilteredList - 1 >= 0) {
-              destIndex = indexInFilteredList
-            }
-          }
           break
         }
       }

--- a/src/views/profile-select.tsx
+++ b/src/views/profile-select.tsx
@@ -1,23 +1,60 @@
 import {Profile} from '../lib/profile'
 import {h} from 'preact'
-import {useCallback} from 'preact/hooks/src'
+import {useCallback} from 'preact/hooks'
 import {StyleSheet, css} from 'aphrodite'
-import {Colors} from './style'
+import {Colors, ZIndex, Sizes} from './style'
 
 interface ProfileSelectRowProps {
   setProfileIndexToView: (profileIndex: number) => void
   profile: Profile
+  selected: boolean
   index: number
+  profileCount: number
 }
 
-export function ProfileSelectRow(props: ProfileSelectRowProps) {
+export function ProfileSelectRow({
+  setProfileIndexToView,
+  profile,
+  selected,
+  profileCount,
+  index,
+}: ProfileSelectRowProps) {
   const onClick = useCallback(() => {
-    props.setProfileIndexToView(props.index)
-  }, [props.setProfileIndexToView, props.index])
+    setProfileIndexToView(index)
+  }, [setProfileIndexToView, index])
+
+  const scrollIntoView = useCallback(
+    (node: HTMLElement | null) => {
+      if (node && selected) {
+        node.scrollIntoView({
+          behavior: 'auto',
+          block: 'nearest',
+          inline: 'nearest',
+        })
+      }
+    },
+    [selected],
+  )
+
+  const name = profile.getName()
+
+  const maxDigits = 1 + Math.floor(Math.log10(profileCount))
 
   return (
-    <div onClick={onClick}>
-      {props.index}: {props.profile.getName()}
+    <div
+      ref={scrollIntoView}
+      onClick={onClick}
+      title={name}
+      className={css(
+        style.profileRow,
+        index % 2 === 0 && style.profileRowEven,
+        selected && style.profileRowSelected,
+      )}
+    >
+      <span className={css(style.profileIndex)} style={{width: maxDigits + 'em'}}>
+        {index + 1}:
+      </span>{' '}
+      {name}
     </div>
   )
 }
@@ -28,27 +65,88 @@ interface ProfileSelectProps {
   profiles: Profile[]
 }
 
-export function ProfileSelect(props: ProfileSelectProps) {
+export function ProfileSelect({profiles, indexToView, setProfileIndexToView}: ProfileSelectProps) {
   return (
-    <div className={css(style.profileSelect)}>
-      {props.profiles.map((p, i) => {
-        return (
-          <ProfileSelectRow
-            key={i}
-            index={i}
-            profile={p}
-            setProfileIndexToView={props.setProfileIndexToView}
-          />
-        )
-      })}
+    <div className={css(style.profileSelectOuter)}>
+      <div className={css(style.caret)} />
+      <div className={css(style.profileSelectBox)}>
+        <div className={css(style.profileSelectScrolling)}>
+          {profiles.map((p, i) => {
+            return (
+              <ProfileSelectRow
+                index={i}
+                selected={i === indexToView}
+                profile={p}
+                profileCount={profiles.length}
+                setProfileIndexToView={setProfileIndexToView}
+              />
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }
 
+const paddingHeight = 10
+
 const style = StyleSheet.create({
-  profileSelect: {
-    width: 480,
+  caret: {
+    width: 0,
+    height: 0,
+    borderLeft: '5px solid transparent',
+    borderRight: '5px solid transparent',
+    borderBottom: '5px solid black',
+  },
+  padding: {
+    height: paddingHeight,
+    background: Colors.BLACK,
+  },
+  profileRow: {
+    height: Sizes.FRAME_HEIGHT - 2,
+    border: '1px solid transparent',
+    textAlign: 'left',
+    paddingLeft: 10,
+    paddingRight: 10,
+    background: Colors.BLACK,
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+    cursor: 'pointer',
+    ':hover': {
+      border: `1px solid ${Colors.DARK_BLUE}`,
+    },
+  },
+  profileRowSelected: {
+    background: Colors.DARK_BLUE,
+  },
+  profileRowEven: {
+    background: Colors.DARK_GRAY,
+  },
+  profileSelectScrolling: {
+    maxHeight: `min(calc(100vh - ${Sizes.TOOLBAR_HEIGHT - 2 * paddingHeight}px), ${
+      20.5 * Sizes.FRAME_HEIGHT
+    }px)`,
+    overflow: 'auto',
+  },
+  profileSelectBox: {
+    width: '100%',
+    maxWidth: 480,
+    paddingTop: 10,
+    paddingBottom: 10,
     background: Colors.BLACK,
     color: Colors.WHITE,
+  },
+  profileSelectOuter: {
+    position: 'relative',
+    zIndex: ZIndex.PROFILE_SELECT,
+    alignItems: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  profileIndex: {
+    textAlign: 'right',
+    display: 'inline-block',
+    color: Colors.LIGHT_GRAY,
   },
 })

--- a/src/views/profile-select.tsx
+++ b/src/views/profile-select.tsx
@@ -1,0 +1,54 @@
+import {Profile} from '../lib/profile'
+import {h} from 'preact'
+import {useCallback} from 'preact/hooks/src'
+import {StyleSheet, css} from 'aphrodite'
+import {Colors} from './style'
+
+interface ProfileSelectRowProps {
+  setProfileIndexToView: (profileIndex: number) => void
+  profile: Profile
+  index: number
+}
+
+export function ProfileSelectRow(props: ProfileSelectRowProps) {
+  const onClick = useCallback(() => {
+    props.setProfileIndexToView(props.index)
+  }, [props.setProfileIndexToView, props.index])
+
+  return (
+    <div onClick={onClick}>
+      {props.index}: {props.profile.getName()}
+    </div>
+  )
+}
+
+interface ProfileSelectProps {
+  setProfileIndexToView: (profileIndex: number) => void
+  indexToView: number
+  profiles: Profile[]
+}
+
+export function ProfileSelect(props: ProfileSelectProps) {
+  return (
+    <div className={css(style.profileSelect)}>
+      {props.profiles.map((p, i) => {
+        return (
+          <ProfileSelectRow
+            key={i}
+            index={i}
+            profile={p}
+            setProfileIndexToView={props.setProfileIndexToView}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+const style = StyleSheet.create({
+  profileSelect: {
+    width: 480,
+    background: Colors.BLACK,
+    color: Colors.WHITE,
+  },
+})

--- a/src/views/profile-select.tsx
+++ b/src/views/profile-select.tsx
@@ -1,6 +1,6 @@
 import {Profile} from '../lib/profile'
 import {h} from 'preact'
-import {useCallback, useState, useEffect} from 'preact/hooks'
+import {useCallback, useState} from 'preact/hooks'
 import {StyleSheet, css} from 'aphrodite'
 import {Colors, ZIndex, Sizes} from './style'
 

--- a/src/views/profile-select.tsx
+++ b/src/views/profile-select.tsx
@@ -26,7 +26,7 @@ export function ProfileSelectRow({
   const onMouseUp = useCallback(() => {
     closeProfileSelect()
     setProfileIndexToView(index)
-  }, [setProfileIndexToView, index])
+  }, [closeProfileSelect, setProfileIndexToView, index])
 
   const scrollIntoView = useCallback(
     (node: HTMLElement | null) => {

--- a/src/views/profile-select.tsx
+++ b/src/views/profile-select.tsx
@@ -10,6 +10,7 @@ interface ProfileSelectRowProps {
   selected: boolean
   index: number
   profileCount: number
+  closeProfileSelect: () => void
 }
 
 export function ProfileSelectRow({
@@ -17,9 +18,11 @@ export function ProfileSelectRow({
   profile,
   selected,
   profileCount,
+  closeProfileSelect,
   index,
 }: ProfileSelectRowProps) {
-  const onClick = useCallback(() => {
+  const onMouseUp = useCallback(() => {
+    closeProfileSelect()
     setProfileIndexToView(index)
   }, [setProfileIndexToView, index])
 
@@ -43,7 +46,7 @@ export function ProfileSelectRow({
   return (
     <div
       ref={scrollIntoView}
-      onClick={onClick}
+      onMouseUp={onMouseUp}
       title={name}
       className={css(
         style.profileRow,
@@ -63,9 +66,15 @@ interface ProfileSelectProps {
   setProfileIndexToView: (profileIndex: number) => void
   indexToView: number
   profiles: Profile[]
+  closeProfileSelect: () => void
 }
 
-export function ProfileSelect({profiles, indexToView, setProfileIndexToView}: ProfileSelectProps) {
+export function ProfileSelect({
+  profiles,
+  closeProfileSelect,
+  indexToView,
+  setProfileIndexToView,
+}: ProfileSelectProps) {
   return (
     <div className={css(style.profileSelectOuter)}>
       <div className={css(style.caret)} />
@@ -79,6 +88,7 @@ export function ProfileSelect({profiles, indexToView, setProfileIndexToView}: Pr
                 profile={p}
                 profileCount={profiles.length}
                 setProfileIndexToView={setProfileIndexToView}
+                closeProfileSelect={closeProfileSelect}
               />
             )
           })}
@@ -131,13 +141,15 @@ const style = StyleSheet.create({
   },
   profileSelectBox: {
     width: '100%',
-    maxWidth: 480,
     paddingTop: 10,
     paddingBottom: 10,
     background: Colors.BLACK,
     color: Colors.WHITE,
   },
   profileSelectOuter: {
+    width: '100%',
+    maxWidth: 480,
+    margin: '0 auto',
     position: 'relative',
     zIndex: ZIndex.PROFILE_SELECT,
     alignItems: 'center',

--- a/src/views/profile-select.tsx
+++ b/src/views/profile-select.tsx
@@ -10,6 +10,7 @@ interface ProfileSelectRowProps {
   selected: boolean
   index: number
   profileCount: number
+  selectIsVisible: boolean
   closeProfileSelect: () => void
 }
 
@@ -18,6 +19,7 @@ export function ProfileSelectRow({
   profile,
   selected,
   profileCount,
+  selectIsVisible,
   closeProfileSelect,
   index,
 }: ProfileSelectRowProps) {
@@ -29,14 +31,16 @@ export function ProfileSelectRow({
   const scrollIntoView = useCallback(
     (node: HTMLElement | null) => {
       if (node && selected) {
-        node.scrollIntoView({
-          behavior: 'auto',
-          block: 'nearest',
-          inline: 'nearest',
+        requestAnimationFrame(() => {
+          node.scrollIntoView({
+            behavior: 'auto',
+            block: 'nearest',
+            inline: 'nearest',
+          })
         })
       }
     },
-    [selected],
+    [selected, selectIsVisible],
   )
 
   const name = profile.getName()
@@ -67,14 +71,20 @@ interface ProfileSelectProps {
   indexToView: number
   profiles: Profile[]
   closeProfileSelect: () => void
+  visible: boolean
 }
 
 export function ProfileSelect({
   profiles,
   closeProfileSelect,
   indexToView,
+  visible,
   setProfileIndexToView,
 }: ProfileSelectProps) {
+  // We allow ProfileSelect to be aware of its own visibility in order to retain
+  // its scroll offset state between times when it's hidden & shown, and also to
+  // scroll the selected node into view once it becomes shown again after the
+  // selected profile has changed.
   return (
     <div className={css(style.profileSelectOuter)}>
       <div className={css(style.caret)} />
@@ -87,6 +97,7 @@ export function ProfileSelect({
                 selected={i === indexToView}
                 profile={p}
                 profileCount={profiles.length}
+                selectIsVisible={visible}
                 setProfileIndexToView={setProfileIndexToView}
                 closeProfileSelect={closeProfileSelect}
               />

--- a/src/views/style.ts
+++ b/src/views/style.ts
@@ -40,7 +40,8 @@ export enum Duration {
 }
 
 export enum ZIndex {
-  HOVERTIP = 1,
+  PROFILE_SELECT = 1,
+  HOVERTIP = 2,
 }
 
 export const commonStyle = StyleSheet.create({

--- a/src/views/toolbar.tsx
+++ b/src/views/toolbar.tsx
@@ -1,7 +1,7 @@
 import {ApplicationProps} from './application'
 import {ViewMode} from '../store'
 import {h, JSX, Fragment} from 'preact'
-import {useCallback, useMemo} from 'preact/hooks'
+import {useCallback, useMemo, useState} from 'preact/hooks'
 import {StyleSheet, css} from 'aphrodite'
 import {Sizes, Colors, FontFamily, FontSize, Duration} from './style'
 import {ProfileSelect} from './profile-select'
@@ -58,6 +58,15 @@ function ToolbarLeftContent(props: ToolbarProps) {
 function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
   const {activeProfileState, profileGroup} = props
   const profiles = useMemo(() => profileGroup?.profiles.map(p => p.profile) || [], [profileGroup])
+  const [profileSelectShown, setProfileSelectShown] = useState(false)
+
+  const openProfileSelect = useCallback(() => {
+    setProfileSelectShown(true)
+  }, [setProfileSelectShown])
+
+  const closeProfileSelect = useCallback(() => {
+    setProfileSelectShown(false)
+  }, [setProfileSelectShown])
 
   if (activeProfileState && profileGroup) {
     const {index} = activeProfileState
@@ -80,6 +89,8 @@ function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
         )
       }
 
+      // TODO(jlfwong): These event handlers are going to be unbound and rebound
+      // on every render because the lambda callbacks are new on every render.
       const prevButton = makeNavButton('⬅️', index === 0, () =>
         props.setProfileIndexToView(index - 1),
       )
@@ -88,18 +99,23 @@ function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
       )
 
       return (
-        <div className={css(style.toolbarCenter)}>
+        <div className={css(style.toolbarCenter)} onMouseLeave={closeProfileSelect}>
           {prevButton}
-          {activeProfileState.profile.getName()}{' '}
-          <span className={css(style.toolbarProfileIndex)}>
-            ({activeProfileState.index + 1}/{profileGroup.profiles.length})
+          <span onMouseOver={openProfileSelect}>
+            {activeProfileState.profile.getName()}{' '}
+            <span className={css(style.toolbarProfileIndex)}>
+              ({activeProfileState.index + 1}/{profileGroup.profiles.length})
+            </span>
           </span>
           {nextButton}
-          <ProfileSelect
-            setProfileIndexToView={props.setProfileIndexToView}
-            indexToView={profileGroup.indexToView}
-            profiles={profiles}
-          />
+          {profileSelectShown && (
+            <ProfileSelect
+              setProfileIndexToView={props.setProfileIndexToView}
+              indexToView={profileGroup.indexToView}
+              profiles={profiles}
+              closeProfileSelect={closeProfileSelect}
+            />
+          )}
         </div>
       )
     }

--- a/src/views/toolbar.tsx
+++ b/src/views/toolbar.tsx
@@ -1,7 +1,7 @@
 import {ApplicationProps} from './application'
 import {ViewMode} from '../store'
 import {h, JSX, Fragment} from 'preact'
-import {useCallback, useState} from 'preact/hooks'
+import {useCallback, useState, useEffect} from 'preact/hooks'
 import {StyleSheet, css} from 'aphrodite'
 import {Sizes, Colors, FontFamily, FontSize, Duration} from './style'
 import {ProfileSelect} from './profile-select'
@@ -93,6 +93,21 @@ function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
 
   const closeProfileSelect = useCallback(() => {
     setProfileSelectShown(false)
+  }, [setProfileSelectShown])
+
+  const onKeyUp = useCallback((ev: KeyboardEvent) => {}, [setProfileSelectShown])
+
+  useEffect(() => {
+    const onWindowKeyPress = (ev: KeyboardEvent) => {
+      if (ev.key === 't') {
+        ev.preventDefault()
+        setProfileSelectShown(true)
+      }
+    }
+    window.addEventListener('keypress', onWindowKeyPress)
+    return () => {
+      window.removeEventListener('keypress', onWindowKeyPress)
+    }
   }, [setProfileSelectShown])
 
   if (activeProfileState && profileGroup && profiles) {

--- a/src/views/toolbar.tsx
+++ b/src/views/toolbar.tsx
@@ -1,9 +1,10 @@
 import {ApplicationProps} from './application'
 import {ViewMode} from '../store'
 import {h, JSX, Fragment} from 'preact'
-import {useCallback} from 'preact/hooks'
+import {useCallback, useMemo} from 'preact/hooks'
 import {StyleSheet, css} from 'aphrodite'
 import {Sizes, Colors, FontFamily, FontSize, Duration} from './style'
+import {ProfileSelect} from './profile-select'
 
 interface ToolbarProps extends ApplicationProps {
   browseForFile(): void
@@ -56,6 +57,8 @@ function ToolbarLeftContent(props: ToolbarProps) {
 
 function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
   const {activeProfileState, profileGroup} = props
+  const profiles = useMemo(() => profileGroup?.profiles.map(p => p.profile) || [], [profileGroup])
+
   if (activeProfileState && profileGroup) {
     const {index} = activeProfileState
     if (profileGroup.profiles.length === 1) {
@@ -92,6 +95,11 @@ function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
             ({activeProfileState.index + 1}/{profileGroup.profiles.length})
           </span>
           {nextButton}
+          <ProfileSelect
+            setProfileIndexToView={props.setProfileIndexToView}
+            indexToView={profileGroup.indexToView}
+            profiles={profiles}
+          />
         </div>
       )
     }

--- a/src/views/toolbar.tsx
+++ b/src/views/toolbar.tsx
@@ -57,7 +57,9 @@ function ToolbarLeftContent(props: ToolbarProps) {
 
 function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
   const {activeProfileState, profileGroup} = props
-  const profiles = useMemo(() => profileGroup?.profiles.map(p => p.profile) || [], [profileGroup])
+  const profiles = useMemo(() => Array.from(profileGroup?.profiles || []).map(p => p.profile), [
+    profileGroup?.profiles,
+  ])
   const [profileSelectShown, setProfileSelectShown] = useState(false)
 
   const openProfileSelect = useCallback(() => {

--- a/src/views/toolbar.tsx
+++ b/src/views/toolbar.tsx
@@ -95,8 +95,6 @@ function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
     setProfileSelectShown(false)
   }, [setProfileSelectShown])
 
-  const onKeyUp = useCallback((ev: KeyboardEvent) => {}, [setProfileSelectShown])
-
   useEffect(() => {
     const onWindowKeyPress = (ev: KeyboardEvent) => {
       if (ev.key === 't') {

--- a/src/views/toolbar.tsx
+++ b/src/views/toolbar.tsx
@@ -109,45 +109,17 @@ function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
   }, [setProfileSelectShown])
 
   if (activeProfileState && profileGroup && profiles) {
-    const {index} = activeProfileState
     if (profileGroup.profiles.length === 1) {
       return <Fragment>{activeProfileState.profile.getName()}</Fragment>
     } else {
-      function makeNavButton(content: string, disabled: boolean, onClick: () => void) {
-        return (
-          <button
-            disabled={disabled}
-            onClick={onClick}
-            className={css(
-              style.emoji,
-              style.toolbarProfileNavButton,
-              disabled && style.toolbarProfileNavButtonDisabled,
-            )}
-          >
-            {content}
-          </button>
-        )
-      }
-
-      // TODO(jlfwong): These event handlers are going to be unbound and rebound
-      // on every render because the lambda callbacks are new on every render.
-      const prevButton = makeNavButton('⬅️', index === 0, () =>
-        props.setProfileIndexToView(index - 1),
-      )
-      const nextButton = makeNavButton('➡️', index >= profileGroup.profiles.length - 1, () =>
-        props.setProfileIndexToView(index + 1),
-      )
-
       return (
         <div className={css(style.toolbarCenter)} onMouseLeave={closeProfileSelect}>
-          {prevButton}
           <span onMouseOver={openProfileSelect}>
             {activeProfileState.profile.getName()}{' '}
             <span className={css(style.toolbarProfileIndex)}>
               ({activeProfileState.index + 1}/{profileGroup.profiles.length})
             </span>
           </span>
-          {nextButton}
           <div style={{display: profileSelectShown ? 'block' : 'none'}}>
             <ProfileSelect
               setProfileIndexToView={props.setProfileIndexToView}
@@ -241,26 +213,6 @@ const style = StyleSheet.create({
   },
   toolbarProfileIndex: {
     color: Colors.LIGHT_GRAY,
-  },
-  toolbarProfileNavButton: {
-    opacity: 0.8,
-    fontSize: FontSize.TITLE,
-    lineHeight: `${Sizes.TOOLBAR_TAB_HEIGHT}px`,
-    ':hover': {
-      opacity: 1.0,
-    },
-    background: 'none',
-    border: 'none',
-    padding: 0,
-    marginLeft: '0.3em',
-    marginRight: '0.3em',
-    transition: `all ${Duration.HOVER_CHANGE} ease-in`,
-  },
-  toolbarProfileNavButtonDisabled: {
-    opacity: 0.5,
-    ':hover': {
-      opacity: 0.5,
-    },
   },
   toolbarTab: {
     background: Colors.DARK_GRAY,

--- a/src/views/toolbar.tsx
+++ b/src/views/toolbar.tsx
@@ -108,14 +108,15 @@ function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
             </span>
           </span>
           {nextButton}
-          {profileSelectShown && (
+          <div style={{display: profileSelectShown ? 'block' : 'none'}}>
             <ProfileSelect
               setProfileIndexToView={props.setProfileIndexToView}
               indexToView={profileGroup.indexToView}
               profiles={profiles}
               closeProfileSelect={closeProfileSelect}
+              visible={profileSelectShown}
             />
-          )}
+          </div>
         </div>
       )
     }

--- a/src/views/toolbar.tsx
+++ b/src/views/toolbar.tsx
@@ -95,7 +95,7 @@ function ToolbarCenterContent(props: ToolbarProps): JSX.Element {
     setProfileSelectShown(false)
   }, [setProfileSelectShown])
 
-  if (activeProfileState && profileGroup) {
+  if (activeProfileState && profileGroup && profiles) {
     const {index} = activeProfileState
     if (profileGroup.profiles.length === 1) {
       return <Fragment>{activeProfileState.profile.getName()}</Fragment>


### PR DESCRIPTION
This adds much better UI for selecting different profiles within a single import.

![Kapture 2020-05-30 at 21 34 06](https://user-images.githubusercontent.com/150329/83344564-595ce400-a2bd-11ea-8306-e5d8f647b65e.gif)

You can now hover over the middle of the toolbar or hit `t` on your keyboard to bring up the profile selector. From there, you can use fuzzy-find to switch to the profile you want, and hit "enter" to select it. The up and down arrow keys can be used while the profile selector filter input is focused to move through the list of profiles.

I think the "next" and "prev" buttons are now totally useless, so I removed them.

Fixes #167 