### PR TITLE
small fix

### DIFF
--- a/src/import/trace-event.ts
+++ b/src/import/trace-event.ts
@@ -177,6 +177,20 @@ function eventListToProfileGroup(events: TraceEvent[]): ProfileGroup {
       // out-of-order push/pops from the call-stack.
       if (a.ph === 'B' && b.ph === 'E') return 1
       if (a.ph === 'E' && b.ph === 'B') return -1
+
+      // If the two elements are both beginning, then the longer
+      // event should go first because it must wrap the shorter one
+      if(a.ph === 'B' && b.ph ==='B') {
+        if (a.dur > b.dur) return -1
+        if (a.dur < b.dur) return 1
+      }
+
+      // If the two elements are both ending, then the longer
+      // event should go second because it must wrap the shorter one
+      if(a.ph === 'E' && b.ph ==='E') {
+        if (a.dur > b.dur) return 1
+        if (a.dur < b.dur) return -1
+      }
     }
 
     // In all other cases, retain the original sort order.


### PR DESCRIPTION
So in a very narrow case, if the end times or beginning times coincide perfectly, the traces don't show up correctly. Example:

By the way I am SUPER impressed with the quality of this code. It was very easy to find the error and very easy to understand the logic because it was well documented.

```
{
  "traceEvents": [
    {
      "name": "foo",
      "ph": "X",
      "ts": 48585,
      "dur": 69,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::bar",
      "ph": "X",
      "ts": 48586,
      "dur": 1,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::birth",
      "ph": "X",
      "ts": 48609,
      "dur": 44,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo",
      "ph": "X",
      "ts": 48860,
      "dur": 45,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::bar",
      "ph": "X",
      "ts": 48861,
      "dur": 1,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::apply",
      "ph": "X",
      "ts": 48879,
      "dur": 25,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo",
      "ph": "X",
      "ts": 49088,
      "dur": 43,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::bar",
      "ph": "X",
      "ts": 49089,
      "dur": 1,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::apply",
      "ph": "X",
      "ts": 49107,
      "dur": 24,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo",
      "ph": "X",
      "ts": 49315,
      "dur": 43,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::bar",
      "ph": "X",
      "ts": 49316,
      "dur": 1,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::apply",
      "ph": "X",
      "ts": 49334,
      "dur": 24,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo",
      "ph": "X",
      "ts": 49539,
      "dur": 43,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::bar",
      "ph": "X",
      "ts": 49540,
      "dur": 1,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::apply",
      "ph": "X",
      "ts": 49558,
      "dur": 24,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo",
      "ph": "X",
      "ts": 49778,
      "dur": 44,
      "pid": 32588,
      "tid": 32588
    },
    {
      "name": "foo::bar",
      "ph": "X",
      "ts": 49779,
      "dur": 1,
      "pid": 32588,
      "tid": 32588
    }
  ]
}
```