### PR TITLE
Increase contrast for flamechart search results by fading text for unmatched frames

### DIFF
--- a/src/views/flamechart-pan-zoom-view.tsx
+++ b/src/views/flamechart-pan-zoom-view.tsx
@@ -287,7 +287,11 @@ export class FlamechartPanZoomView extends Component<FlamechartPanZoomViewProps,
 
           // Note that this is specifying the position of the starting text
           // baseline.
-          ctx.fillStyle = Colors.DARK_GRAY
+          if (this.props.searchIsActive && this.props.searchQuery.length > 0 && !match) {
+            ctx.fillStyle = Colors.LIGHT_GRAY
+          } else {
+            ctx.fillStyle = Colors.DARK_GRAY
+          }
           ctx.fillText(
             trimmedText.trimmedString,
             physicalLabelBounds.left() + LABEL_PADDING_PX,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/150329/88493052-ee99f300-cf63-11ea-9522-8de032e920ac.png)

After:
![image](https://user-images.githubusercontent.com/150329/88493062-f9548800-cf63-11ea-9e7e-5c87a1dba836.png)

Works towards #38 