### PR TITLE
WIP: load sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   },
   "dependencies": {
     "opn": "5.3.0",
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "source-map": "^0.7.3"
   }
 }

--- a/src/lib/js-source-map.ts
+++ b/src/lib/js-source-map.ts
@@ -1,0 +1,45 @@
+import * as sourcemap from 'source-map'
+import {MappingItem} from 'source-map'
+
+type JavascriptSymbolMap = Map<number, Map<number, string>>
+
+// Looks like the d.ts description doens't properly define `initialize`
+// @ts-ignore
+sourcemap.SourceMapConsumer.initialize({
+  'lib/mappings.wasm': 'https://unpkg.com/source-map@0.7.3/lib/mappings.wasm',
+})
+
+export async function importJavascriptSymbolMap(
+  contentsString: string,
+): Promise<JavascriptSymbolMap | null> {
+  try {
+    const contents = JSON.parse(contentsString)
+
+    if (contents.names == null) {
+      return null
+    }
+
+    if (contents.mappings == null) {
+      return null
+    }
+
+    const result = new Map<number, Map<number, string>>()
+
+    await sourcemap.SourceMapConsumer.with(contents, null, consumer => {
+      consumer.eachMapping(function (m: MappingItem) {
+        const line = m.generatedLine - 1
+        const col = m.generatedColumn + 1
+        if (!result.has(line)) {
+          result.set(line, new Map<number, string>())
+        }
+        result.get(line)?.set(col, m.name)
+      })
+    })
+
+    return result
+  } catch (e) {
+    return null
+  }
+
+  return null
+}

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -413,6 +413,14 @@ export class Profile {
       frame.name = callback(frame.name)
     }
   }
+
+  remapNamesForLineAndColumn(
+    callback: (data: {line?: number; col?: number; name: string}) => string,
+  ) {
+    for (let frame of this.frames) {
+      frame.name = callback(frame)
+    }
+  }
 }
 
 export class StackListProfileBuilder extends Profile {


### PR DESCRIPTION
This is WIP! Let me know what you think of the overall approach and any guideline on testing. This PR is pretty much gluing `speedscope` to Mozilla's `source-map` project. Interestingly, they use a wasm binary to do the decoding quickly.

Another possible approach could be doing the source-map decoding manually, eg like: https://gist.github.com/bengourley/c3c62e41c9b579ecc1d51e9d9eb8b9d2.

I tested this with a tiny test project here: https://gist.github.com/cricklet/0deaaa7dd63657adb6818f0a52362651

## Before:

<img width="1703" alt="Screen Shot 2020-08-05 at 8 22 14 PM" src="https://user-images.githubusercontent.com/659021/89487037-608aed00-d759-11ea-812e-a2ba358303a9.png">

## After:

<img width="1703" alt="Screen Shot 2020-08-05 at 8 22 07 PM" src="https://user-images.githubusercontent.com/659021/89487034-5d8ffc80-d759-11ea-984f-08bcbb303607.png">

Fixes: https://github.com/jlfwong/speedscope/issues/139