### PR TITLE
Callgrind import format support

### DIFF
--- a/sample/profiles/callgrind/callgrind.example.log
+++ b/sample/profiles/callgrind/callgrind.example.log
@@ -1,0 +1,24 @@
+# callgrind format
+events: Instructions
+
+fl=file1.c
+fn=main
+16 20
+cfn=func1
+calls=1 50
+16 400
+cfi=file2.c
+cfn=func2
+calls=3 20
+16 400
+
+fn=func1
+51 100
+cfi=file2.c
+cfn=func2
+calls=2 20
+51 300
+
+fl=file2.c
+fn=func2
+20 700

--- a/sample/profiles/callgrind/callgrind.multiple-event-types.log
+++ b/sample/profiles/callgrind/callgrind.multiple-event-types.log
@@ -1,0 +1,29 @@
+version: 1
+creator: xdebug 3.0.2 (PHP 7.4.14)
+cmd: /var/www/html/index.php
+part: 1
+positions: line
+
+events: Time_(10ns) Memory_(bytes)
+
+fl=(1) file1.c
+fn=(1) main
+16 20 15000
+cfn=(2) func1
+calls=1 50
+16 400 20000
+cfi=(2) file2.c
+cfn=(3) func2
+calls=3 51
+16 400 3000
+
+fn=(2)
+51 100 4000
+cfi=(2)
+cfn=(3)
+calls=2 20
+51 300 5000
+
+fl=(2)
+fn=(3)
+20 700 6000

--- a/sample/profiles/callgrind/callgrind.name-compression.log
+++ b/sample/profiles/callgrind/callgrind.name-compression.log
@@ -1,0 +1,24 @@
+# callgrind format
+events: Instructions
+
+fl=(1) file1.c
+fn=(1) main
+16 20
+cfn=(2) func1
+calls=1 50
+16 400
+cfi=(2) file2.c
+cfn=(3) func2
+calls=3 20
+16 400
+
+fn=(2)
+51 100
+cfi=(2)
+cfn=(3)
+calls=2 20
+51 300
+
+fl=(2)
+fn=(3)
+20 700

--- a/src/import/__snapshots__/callgrind.test.ts.snap
+++ b/src/import/__snapshots__/callgrind.test.ts.snap
@@ -1,0 +1,177 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`importFromCallgrind 1`] = `
+Object {
+  "frames": Array [
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:main",
+      "line": undefined,
+      "name": "main",
+      "selfWeight": 20,
+      "totalWeight": 820,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:func1",
+      "line": undefined,
+      "name": "func1",
+      "selfWeight": 100,
+      "totalWeight": 400,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file2.c",
+      "key": "file2.c:func2",
+      "line": undefined,
+      "name": "func2",
+      "selfWeight": 700,
+      "totalWeight": 700,
+    },
+  ],
+  "name": "callgrind.example.log -- Instructions",
+  "stacks": Array [
+    "main;func1;func2 300",
+    "main;func1 100",
+    "main;func2 400",
+    "main 20",
+  ],
+}
+`;
+
+exports[`importFromCallgrind multiple event types 1`] = `
+Object {
+  "frames": Array [
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:main",
+      "line": undefined,
+      "name": "main",
+      "selfWeight": 200,
+      "totalWeight": 8200,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:func1",
+      "line": undefined,
+      "name": "func1",
+      "selfWeight": 1000,
+      "totalWeight": 4000,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file2.c",
+      "key": "file2.c:func2",
+      "line": undefined,
+      "name": "func2",
+      "selfWeight": 7000,
+      "totalWeight": 7000,
+    },
+  ],
+  "name": "callgrind.multiple-event-types.log -- Time",
+  "stacks": Array [
+    "main;func1;func2 3.00µs",
+    "main;func1 1.00µs",
+    "main;func2 4.00µs",
+    "main 200.00ns",
+  ],
+}
+`;
+
+exports[`importFromCallgrind multiple event types 2`] = `
+Object {
+  "frames": Array [
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:main",
+      "line": undefined,
+      "name": "main",
+      "selfWeight": 15000,
+      "totalWeight": 38000,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:func1",
+      "line": undefined,
+      "name": "func1",
+      "selfWeight": 8888.888888888889,
+      "totalWeight": 20000,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file2.c",
+      "key": "file2.c:func2",
+      "line": undefined,
+      "name": "func2",
+      "selfWeight": 14111.111111111111,
+      "totalWeight": 14111.111111111111,
+    },
+  ],
+  "name": "callgrind.multiple-event-types.log -- Memory",
+  "stacks": Array [
+    "main;func1;func2 10.85 KB",
+    "main;func1 8.68 KB",
+    "main;func2 2.93 KB",
+    "main 14.65 KB",
+  ],
+}
+`;
+
+exports[`importFromCallgrind multiple event types: indexToView 1`] = `0`;
+
+exports[`importFromCallgrind multiple event types: profileGroup.name 1`] = `"callgrind.multiple-event-types.log"`;
+
+exports[`importFromCallgrind name compression 1`] = `
+Object {
+  "frames": Array [
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:main",
+      "line": undefined,
+      "name": "main",
+      "selfWeight": 20,
+      "totalWeight": 820,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:func1",
+      "line": undefined,
+      "name": "func1",
+      "selfWeight": 100,
+      "totalWeight": 400,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file2.c",
+      "key": "file2.c:func2",
+      "line": undefined,
+      "name": "func2",
+      "selfWeight": 700,
+      "totalWeight": 700,
+    },
+  ],
+  "name": "callgrind.name-compression.log -- Instructions",
+  "stacks": Array [
+    "main;func1;func2 300",
+    "main;func1 100",
+    "main;func2 400",
+    "main 20",
+  ],
+}
+`;
+
+exports[`importFromCallgrind name compression: indexToView 1`] = `0`;
+
+exports[`importFromCallgrind name compression: profileGroup.name 1`] = `"callgrind.name-compression.log"`;
+
+exports[`importFromCallgrind: indexToView 1`] = `0`;
+
+exports[`importFromCallgrind: profileGroup.name 1`] = `"callgrind.example.log"`;

--- a/src/import/callgrind.test.ts
+++ b/src/import/callgrind.test.ts
@@ -1,0 +1,13 @@
+import {checkProfileSnapshot} from '../lib/test-utils'
+
+test('importFromCallgrind', async () => {
+  await checkProfileSnapshot('./sample/profiles/callgrind/callgrind.example.log')
+})
+
+test('importFromCallgrind name compression', async () => {
+  await checkProfileSnapshot('./sample/profiles/callgrind/callgrind.name-compression.log')
+})
+
+test('importFromCallgrind multiple event types', async () => {
+  await checkProfileSnapshot('./sample/profiles/callgrind/callgrind.multiple-event-types.log')
+})

--- a/src/import/callgrind.ts
+++ b/src/import/callgrind.ts
@@ -1,0 +1,7 @@
+// https://www.valgrind.org/docs/manual/cl-format.html
+
+import {Profile} from '../lib/profile'
+
+export function importFromCallgrind(contents: string): Profile | null {
+  return null
+}

--- a/src/import/callgrind.ts
+++ b/src/import/callgrind.ts
@@ -1,7 +1,197 @@
 // https://www.valgrind.org/docs/manual/cl-format.html
+//
+// Larger example files can be found by searching on github:
+// https://github.com/search?q=cfn%3D&type=code
 
-import {Profile} from '../lib/profile'
+import {CallTreeProfileBuilder, ProfileGroup} from '../lib/profile'
 
-export function importFromCallgrind(contents: string): Profile | null {
+// In writing this, I initially tried to use the formal grammar described in
+// section 3.2 of https://www.valgrind.org/docs/manual/cl-format.html, but
+// stopped because most of the information isn't relevant for visualization, and
+// because there's inconsistency between the grammar and subsequence
+// descriptions.
+//
+// For example, the grammar for headers specifies all the valid header names,
+// but then the writing below that mentions there may be a "totals" or "summary"
+// header, which should be disallowed by the formal grammar.
+//
+// So, instead, I'm not going to bother with a formal parse. Since there are no
+// real recursive structures in this file format, that should be okay.
+export function importFromCallgrind(contents: string): ProfileGroup | null {
+  const lines = contents.split('\n')
+
+  let profiles: CallTreeProfileBuilder[] | null = null
+  let eventsLine: string | null = null
+
+  let filename: string | null = null
+  let functionName: string | null = null
+  let calledFilename: string | null = null
+  let calledFunctionName: string | null = null
+
+  const savedFileNames: {[id: string]: string} = {}
+  const savedFunctionNames: {[id: string]: string} = {}
+
+  let lineNum = 0
+
+  while (lineNum < lines.length) {
+    const line = lines[lineNum++]
+
+    if (/^\s*#/.exec(line)) {
+      // Line is a comment. Ignore it.
+      continue
+    }
+
+    if (/^\s*$/.exec(line)) {
+      // Line is empty. Ignore it.
+      continue
+    }
+
+    if (parseHeaderLine(line)) {
+      continue
+    }
+
+    if (parseAssignmentLine(line)) {
+      continue
+    }
+
+    if (parseCostLine(line)) {
+      continue
+    }
+
+    throw new Error(`Unrecognized line "${line}" on line ${lineNum}`)
+  }
+
+  function parseHeaderLine(line: string): boolean {
+    const headerMatch = /^\s*(\w+):\s*(.*)+$/.exec(line)
+    if (!headerMatch) return false
+
+    if (headerMatch[1] !== 'events') {
+      // We don't care about other headers. Ignore this line.
+      return true
+    }
+
+    // Line specifies the formatting of subsequent cost lines.
+    const fields = headerMatch[2].split(' ')
+    console.log('found fields', fields)
+
+    if (profiles != null) {
+      throw new Error(
+        `Duplicate "events: " lines specified. First was "${eventsLine}", now received "${line}" on ${lineNum}.`,
+      )
+    }
+
+    profiles = fields.map(f => {
+      const profile = new CallTreeProfileBuilder()
+
+      // TODO(jlfwong): Make this name also incldue the imported file name.
+      profile.setName(f)
+
+      return profile
+    })
+
+    return true
+  }
+
+  function parseAssignmentLine(line: string): boolean {
+    const assignmentMatch = /^(\w+)=\s*(.*)$/.exec(line)
+    if (!assignmentMatch) return false
+
+    const key = assignmentMatch[1]
+    const value = assignmentMatch[2]
+
+    switch (key) {
+      case 'fi':
+      case 'fe':
+      case 'fl': {
+        filename = parseNameWithCompression(value, savedFileNames)
+        break
+      }
+
+      case 'fn': {
+        functionName = parseNameWithCompression(value, savedFunctionNames)
+        break
+      }
+
+      case 'cfi':
+      case 'cfl': {
+        calledFilename = parseNameWithCompression(value, savedFileNames)
+        break
+      }
+
+      case 'cfn': {
+        calledFunctionName = parseNameWithCompression(value, savedFunctionNames)
+        break
+      }
+
+      case 'calls': {
+        // TODO(jlfwong): Implement this
+        break
+      }
+
+      default: {
+        console.log(`Ignoring assignment to unrecognized key "${key}"`)
+      }
+    }
+
+    return true
+  }
+
+  function parseNameWithCompression(name: string, saved: {[id: string]: string}): string {
+    {
+      const nameDefinitionMatch = /^\((\d+)\)\s*(.+)$/.exec(name)
+
+      if (nameDefinitionMatch) {
+        const id = nameDefinitionMatch[1]
+        const name = nameDefinitionMatch[2]
+        if (id in saved) {
+          throw new Error(
+            `Redefinition of name with id: ${id}. Original value was "${saved[id]}". Tried to redefine as "${name}" on line ${lineNum}.`,
+          )
+        }
+
+        saved[id] = name
+        return name
+      }
+    }
+
+    {
+      const nameUseMatch = /^\((\d+)\)$/.exec(name)
+      if (nameUseMatch) {
+        const id = nameUseMatch[1]
+        if (!(id in saved)) {
+          throw new Error(
+            `Tried to use name with id ${id} on line ${lineNum} before it was defined.`,
+          )
+        }
+        return saved[id]
+      }
+    }
+
+    return name
+  }
+
+  function parseCostLine(line: string): boolean {
+    // TODO(jlfwong): Handle "Subposition compression"
+    // TODO(jlfwong): Allow hexadecimal encoding
+
+    const parts = line.split(/\s+/)
+    const nums: number[] = []
+    for (let part of parts) {
+      // As far as I can tell from the specification, the callgrind format does
+      // not accept floating point numbers.
+      const asNum = parseInt(part)
+      if (isNaN(asNum)) {
+        return false
+      }
+
+      nums.push(asNum)
+    }
+
+    // TODO(jlfwong): remove this
+    console.log(`fl=${filename} fn=${functionName} cost line=${nums.join(',')}`)
+
+    return true
+  }
+
   return null
 }

--- a/src/import/callgrind.ts
+++ b/src/import/callgrind.ts
@@ -150,11 +150,14 @@ class CallGraph {
 
     const profile = new CallTreeProfileBuilder()
 
+    let unitMultiplier = 1
+
     // These are common field names used by Xdebug. Let's give them special
     // treatment to more helpfully display units.
     if (this.fieldName === 'Time_(10ns)') {
       profile.setName(`${this.fileName} -- Time`)
-      profile.setValueFormatter(new TimeFormatter('nanoseconds', 10))
+      unitMultiplier = 10
+      profile.setValueFormatter(new TimeFormatter('nanoseconds'))
     } else if (this.fieldName == 'Memory_(bytes)') {
       profile.setName(`${this.fileName} -- Memory`)
       profile.setValueFormatter(new ByteFormatter())
@@ -234,7 +237,7 @@ class CallGraph {
 
       let selfWeightForFrame = callGraphWeightForFrame
 
-      profile.enterFrame(frame, totalCumulative)
+      profile.enterFrame(frame, totalCumulative * unitMultiplier)
 
       currentStack.add(frame)
       for (let [child, callGraphEdgeWeight] of this.childrenTotalWeights.get(frame) || []) {
@@ -245,7 +248,7 @@ class CallGraph {
       currentStack.delete(frame)
 
       totalCumulative += selfWeightForFrame * ratio
-      profile.leaveFrame(frame, totalCumulative)
+      profile.leaveFrame(frame, totalCumulative * unitMultiplier)
     }
 
     for (let [rootFrame, rootWeight] of rootWeights) {

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -136,7 +136,8 @@ async function _importProfileGroup(dataSource: ProfileDataSource): Promise<Profi
   } else if (fileName.endsWith('-recording.json')) {
     console.log('Importing as Safari profile')
     return toGroup(importFromSafari(JSON.parse(contents)))
-  } else if (fileName.startsWith('callgrind.') {
+  } else if (fileName.startsWith('callgrind.')) {
+    console.log('Importing as Callgrind profile')
     return importFromCallgrind(contents, fileName)
   }
 
@@ -189,7 +190,8 @@ async function _importProfileGroup(dataSource: ProfileDataSource): Promise<Profi
       /^# callgrind format/.exec(contents) ||
       (/^events:/m.exec(contents) && /^fn=/m.exec(contents))
     ) {
-      return importFromCallgrind(contents)
+      console.log('Importing as Callgrind profile')
+      return importFromCallgrind(contents, fileName)
     }
 
     // If the first line contains "Symbol Name", preceded by a tab, it's probably

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -183,8 +183,11 @@ async function _importProfileGroup(dataSource: ProfileDataSource): Promise<Profi
 
     // If the first line is "# callgrind format", it's probably in Callgrind
     // Profile Format.
-    if (/^# callgrind format/.exec(contents)) {
-      return toGroup(importFromCallgrind(contents))
+    if (
+      /^# callgrind format/.exec(contents) ||
+      (/^events:/m.exec(contents) && /^fn=/m.exec(contents))
+    ) {
+      return importFromCallgrind(contents)
     }
 
     // If the first line contains "Symbol Name", preceded by a tab, it's probably

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -21,6 +21,7 @@ import {importAsPprofProfile} from './pprof'
 import {decodeBase64} from '../lib/utils'
 import {importFromChromeHeapProfile} from './v8heapalloc'
 import {isTraceEventFormatted, importTraceEvents} from './trace-event'
+import {importFromCallgrind} from './callgrind'
 
 export async function importProfileGroupFromText(
   fileName: string,
@@ -179,6 +180,12 @@ async function _importProfileGroup(dataSource: ProfileDataSource): Promise<Profi
     }
   } else {
     // Format is not JSON
+
+    // If the first line is "# callgrind format", it's probably in Callgrind
+    // Profile Format.
+    if (/^# callgrind format/.exec(contents)) {
+      return toGroup(importFromCallgrind(contents))
+    }
 
     // If the first line contains "Symbol Name", preceded by a tab, it's probably
     // a deep copy from OS X Instruments.app

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -136,6 +136,8 @@ async function _importProfileGroup(dataSource: ProfileDataSource): Promise<Profi
   } else if (fileName.endsWith('-recording.json')) {
     console.log('Importing as Safari profile')
     return toGroup(importFromSafari(JSON.parse(contents)))
+  } else if (fileName.startsWith('callgrind.') {
+    return importFromCallgrind(contents, fileName)
   }
 
   // Second pass: Try to guess what file format it is based on structure


### PR DESCRIPTION
Implements import from the [callgrind format](https://www.valgrind.org/docs/manual/cl-format.html).

This comes with a big caveat that the call graph information contained with callgrind formatted files don't uniquely define a flamegraph, so the generated flamegraph is a best-effort guess. Here's the comment from the top of the main file for the callgrind importer with an examplataion:

```
// https://www.valgrind.org/docs/manual/cl-format.html
//
// Larger example files can be found by searching on github:
// https://github.com/search?q=cfn%3D&type=code
//
// Converting callgrind files into flamegraphs is challenging because callgrind
// formatted profiles contain call graphs with weighted nodes and edges, and
// such a weighted call graph does not uniquely define a flamegraph.
//
// Consider a program that looks like this:
//
//    // example.js
//    function backup(read) {
//      if (read) {
//        read()
//      } else {
//        write()
//      }
//    }
//
//    function start() {
//       backup(true)
//    }
//
//    function end() {
//       backup(false)
//    }
//
//    start()
//    end()
//
// Profiling this program might result in a profile that looks like the
// following flame graph defined in Brendan Gregg's plaintext format:
//
//    start;backup;read 4
//    end;backup;write 4
//
// When we convert this execution into a call-graph, we get the following:
//
//      +------------------+     +---------------+
//      | start (self: 0)  |     | end (self: 0) |
//      +------------------+     +---------------|
//                   \               /
//        (total: 4)  \             / (total: 4)
//                     v           v
//                 +------------------+
//                 | backup (self: 0) |
//                 +------------------+
//                    /            \
//       (total: 4)  /              \ (total: 4)
//                  v                v
//      +----------------+      +-----------------+
//      | read (self: 4) |      | write (self: 4) |
//      +----------------+      +-----------------+
//
// In the process of the conversion, we've lost information about the ratio of
// time spent in read v.s. write in the start call v.s. the end call. The
// following flame graph would yield the exact same call-graph, and therefore
// the exact sample call-grind formatted profile:
//
//    start;backup;read 3
//    start;backup;write 1
//    end;backup;read 1
//    end;backup;write 3
//
// This is unfortunate, since it means we can't produce a flamegraph that isn't
// potentially lying about the what the actual execution behavior was. To
// produce a flamegraph at all from the call graph representation, we have to
// decide how much weight each sub-call should have. Given that we know the
// total weight of each node, we'll make the incorrect assumption that every
// invocation of a function will have the average distribution of costs among
// the sub-function invocations. In the example given, this means we assume that
// every invocation of backup() is assumed to spend half its time in read() and
// half its time in write().
//
// So the flamegraph we'll produce from the given call-graph will actually be:
//
//    start;backup;read 2
//    start;backup;write 2
//    end;backup;read 2
//    end;backup;write 2
//
// A particularly bad consequence is that the resulting flamegraph will suggest
// that there was at some point a call stack that looked like
// strat;backup;write, even though that never happened in the real program
// execution.
```

Fixes #18