### PR TITLE
Support relative URLs

### DIFF
--- a/src/views/application.tsx
+++ b/src/views/application.tsx
@@ -411,7 +411,8 @@ export class Application extends StatelessComponent<ApplicationProps> {
   }
 
   async maybeLoadHashParamProfile() {
-    if (this.props.hashParams.profileURL) {
+    const {profileURL} = this.props.hashParams;
+    if (profileURL) {
       if (!canUseXHR) {
         alert(
           `Cannot load a profile URL when loading from "${window.location.protocol}" URL protocol`,
@@ -419,8 +420,8 @@ export class Application extends StatelessComponent<ApplicationProps> {
         return
       }
       this.loadProfile(async () => {
-        const response: Response = await fetch(this.props.hashParams.profileURL!)
-        let filename = new URL(this.props.hashParams.profileURL!).pathname
+        const response: Response = await fetch(profileURL)
+        let filename = new URL(profileURL, window.location.href).pathname
         if (filename.includes('/')) {
           filename = filename.slice(filename.lastIndexOf('/') + 1)
         }


### PR DESCRIPTION
Fixes #312 

This turns out not to be very deep: you have to pass an optional second parameter to the [`URL` constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) to resolve relative URLs.

```
> new URL('/path/to/file#hashcode').pathnaem
VM252:1 Uncaught TypeError: Failed to construct 'URL': Invalid URL
    at <anonymous>:1:1
(anonymous) @ VM252:1
> new URL('/path/to/file#hashcode', 'http://example.com/').pathname
"/path/to/file"
```