### PR TITLE
add "c" shortcut to slice a profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Once a profile has loaded, the main view is split into two: the top area is the 
 * `n`: Go to next profile/thread if one is available
 * `p`: Go to previous profile/thread if one is available
 * `t`: Open the profile/thread selector if available
+* `c`: Slice the profile by the current selecting in "Time Order" view
 * `Cmd+F`/`Ctrl+F`: to open search. While open, `Enter` and `Shift+Enter` cycle through results
 
 ## Contributing

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -328,6 +328,33 @@ export class Profile {
     return flattenedProfile
   }
 
+  getProfileSlice(start: number, end: number): Profile {
+    const builder = new CallTreeProfileBuilder()
+
+    let lastValue = 0
+
+    function openFrame(node: CallTreeNode, value: number) {
+      builder.enterFrame(
+        node.frame,
+        (lastValue = value >= end || value < start ? lastValue : value - start),
+      )
+    }
+    function closeFrame(node: CallTreeNode, value: number) {
+      builder.leaveFrame(
+        node.frame,
+        (lastValue = value >= end || value < start ? lastValue : value - start),
+      )
+    }
+
+    this.forEachCall(openFrame, closeFrame)
+
+    const slice = builder.build()
+    slice.name = this.name
+    slice.valueFormatter = this.valueFormatter
+
+    return slice
+  }
+
   getInvertedProfileForCallersOf(focalFrameInfo: FrameInfo): Profile {
     const focalFrame = Frame.getOrInsert(this.frames, focalFrameInfo)
     const builder = new StackListProfileBuilder()

--- a/src/views/application.tsx
+++ b/src/views/application.tsx
@@ -349,6 +349,17 @@ export class Application extends StatelessComponent<ApplicationProps> {
       if (activeProfileState) {
         this.props.setProfileIndexToView(activeProfileState.index - 1)
       }
+    } else if (ev.key === 'c') {
+      const {activeProfileState, profileGroup, setProfileGroup} = this.props
+      if (activeProfileState && profileGroup) {
+        const start = activeProfileState.chronoViewState.configSpaceViewportRect.origin.x
+        const end = start + activeProfileState.chronoViewState.configSpaceViewportRect.size.x
+        setProfileGroup({
+          name: profileGroup.name,
+          indexToView: 0,
+          profiles: [activeProfileState.profile.getProfileSlice(start, end)],
+        })
+      }
     }
   }
 


### PR DESCRIPTION
Pressing "c" will slice the profile to the selected area.

This allows to focus on a selected area of the profile and analyse that in deep with "Left Heavy" or "Sandwich" view.