### PR TITLE
Add phpspy and php-profiler to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ speedscope is designed to ingest profiles from a variety of different profilers 
   - [Importing from py-spy](https://github.com/jlfwong/speedscope/wiki/Importing-from-py-spy-(python))
   - [pyspeedscope](https://github.com/windelbouwman/pyspeedscope)
   - [Importing from Austin](https://github.com/P403n1x87/austin-python#format-conversion)
+- PHP
+  - [Importing from phpspy or sj-i/php-profiler](https://github.com/sj-i/php-profiler/pull/101)
 - Go
   - [Importing from pprof](https://github.com/jlfwong/speedscope/wiki/Importing-from-pprof-(go))  
 - Rust


### PR DESCRIPTION
- [phpspy](https://github.com/adsr/phpspy) is a sampling profiler for PHP inspired by rbspy and py-spy.
- [sj-i/php-profiler](https://github.com/sj-i/php-profiler) is also a sampling profiler inspired by phpspy.