### PR TITLE
fix(bg-flamegraph): ignore comment lines

### DIFF
--- a/sample/profiles/stackcollapse/simple-with-invalids.txt
+++ b/sample/profiles/stackcollapse/simple-with-invalids.txt
@@ -6,3 +6,5 @@ a;b;d 4
 a;b;c 3
 a;b 5
 invalid line
+
+# duration: 1000

--- a/src/import/bg-flamegraph.ts
+++ b/src/import/bg-flamegraph.ts
@@ -9,7 +9,7 @@ interface BGSample {
 
 function parseBGFoldedStacks(contents: string): BGSample[] {
   const samples: BGSample[] = []
-  contents.replace(/^(.*) (\d+)$/gm, (match: string, stack: string, n: string) => {
+  contents.replace(/(^[^#\n].*) (\d+)$/gm, (match: string, stack: string, n: string) => {
     samples.push({
       stack: stack.split(';').map(name => ({key: name, name: name})),
       duration: parseInt(n, 10),


### PR DESCRIPTION
This fix ignores any lines starting with a hash character in folded stack file formats. This allows the raw output generated by Austin 3 to be imported directly without any of the extra metadata lines littering the flame graph visualisation.