### PR TITLE
Add note about pyinstrument support wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ speedscope is designed to ingest profiles from a variety of different profilers 
   - [Importing from py-spy](https://github.com/jlfwong/speedscope/wiki/Importing-from-py-spy-(python))
   - [pyspeedscope](https://github.com/windelbouwman/pyspeedscope)
   - [Importing from Austin](https://github.com/P403n1x87/austin-python#format-conversion)
+  - [Importing from pyinstrument](https://github.com/jlfwong/speedscope/wiki/Importing-from-pyinstrument-(python))
 - Go
   - [Importing from pprof](https://github.com/jlfwong/speedscope/wiki/Importing-from-pprof-(go))  
 - Rust


### PR DESCRIPTION
Hello @jlfwong ! 

Thanks to the efforts of @goxberry over in https://github.com/joerick/pyinstrument/pull/160, my profiler pyinstrument now supports speedscope JSON as an output. I thought you might want to mention it in your README.

I couldn't create the wiki page myself, but if you're able to copy paste this as a new page into the wiki that should work:

**Importing from pyinstrument (python)**

```markdown
pyinstrument is a statistical profiler for Python.

pyinstrument has an explicit output format for speedscope (See: https://github.com/joerick/pyinstrument/pull/160).

To profile a Python script and view the output in speedscope, run:

    pyinstrument -r speedscope -o profile.speedscope.json your_script.py

Or, you can profile a specific block of code using:

    from pyinstrument import Profiler
    from pyinstrument.renderers import SpeedscopeRenderer
    
    with Profiler() as profiler:
        ... # your code here

    with open('profile.speedscope.json', 'w') as f:
        f.write(profiler.render(renderer=SpeedscopeRenderer()))

Then drop the resulting profile.speedscope.json into https://www.speedscope.app/
```