### PR TITLE
fix: shouldn't merge (program) call frame

### DIFF
--- a/src/import/chrome.ts
+++ b/src/import/chrome.ts
@@ -203,7 +203,7 @@ function shouldIgnoreFunction(callFrame: CPUProfileCallFrame) {
 }
 
 function shouldPlaceOnTopOfPreviousStack(functionName: string) {
-  return functionName === '(garbage collector)' || functionName === '(program)'
+  return functionName === '(garbage collector)'
 }
 
 export function importFromChromeCPUProfile(chromeProfile: CPUProfile): Profile {


### PR DESCRIPTION
Hi, thanks for this great work!

I am able to use speedscope to analyze `.cpuprofile`, but sometimes it behaves differently with devtools:

> [CPU-20200515T093903.cpuprofile.zip](https://github.com/jlfwong/speedscope/files/7719038/CPU-20200515T093903.cpuprofile.zip)

`CPU-20200515T093903.cpuprofile` in speedscope:

![image](https://user-images.githubusercontent.com/19908330/146181030-48bb45ff-0d4b-4cd2-8404-1db89dcad9b8.png)

And in devtools the flamegraph is like:

![image](https://user-images.githubusercontent.com/19908330/146181155-0ad948ff-aff2-448e-a2c7-d67098bbf7a0.png)

---

> https://github.com/jlfwong/speedscope/blob/main/src/import/chrome.ts#L205-L207

Maybe we shouldn't to merge the `(program)` frame to keep the same behavior  with chrome devtools.

