### PR TITLE
add support for JS Self-Profiling data

### DIFF
--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -22,6 +22,7 @@ import {decodeBase64} from '../lib/utils'
 import {importFromChromeHeapProfile} from './v8heapalloc'
 import {isTraceEventFormatted, importTraceEvents} from './trace-event'
 import {importFromCallgrind} from './callgrind'
+import {importFromJSSelfProfiling} from './js-self-profiling'
 
 export async function importProfileGroupFromText(
   fileName: string,
@@ -180,6 +181,14 @@ async function _importProfileGroup(dataSource: ProfileDataSource): Promise<Profi
     } else if ('recording' in parsed && 'sampleStackTraces' in parsed.recording) {
       console.log('Importing as Safari profile')
       return toGroup(importFromSafari(JSON.parse(contents)))
+    } else if (
+      'frames' in parsed &&
+      'resources' in parsed &&
+      'stacks' in parsed &&
+      'samples' in parsed
+    ) {
+      console.log('Importing as JS Self-Profiling')
+      return importFromJSSelfProfiling(parsed)
     }
   } else {
     // Format is not JSON

--- a/src/import/js-self-profiling.ts
+++ b/src/import/js-self-profiling.ts
@@ -1,0 +1,71 @@
+import {importSpeedscopeProfiles} from '../lib/file-format'
+import {FileFormat} from '../lib/file-format-spec'
+import {ProfileGroup} from '../lib/profile'
+
+type Sample = {
+  timestamp: number
+  stackId?: number
+}
+type Frame = {
+  name: string
+  column?: number
+  line?: number
+  resourceId?: number
+}
+type StackNode = {
+  frameId: number
+  parentId?: number
+}
+type JSSelfProfilingData = {
+  samples: Sample[]
+  resources: string[]
+  frames: Frame[]
+  stacks: StackNode[]
+}
+
+function jsspToSpeedscope(json: JSSelfProfilingData): FileFormat.File {
+  function getFrames(stackId: number | undefined): number[] {
+    if (stackId == null) return []
+    const {frameId, parentId} = json.stacks[stackId]
+    return [...getFrames(parentId), frameId]
+  }
+
+  const profile = {
+    type: FileFormat.ProfileType.SAMPLED,
+    name: 'profile',
+    unit: 'milliseconds',
+    startValue: Math.min.apply(
+      null,
+      json.samples.map(s => s.timestamp),
+    ),
+    endValue: Math.max.apply(
+      null,
+      json.samples.map(s => s.timestamp),
+    ),
+    samples: json.samples.map(({stackId}) => getFrames(stackId)),
+    weights: json.samples.map(({timestamp}, i) =>
+      i === 0 ? 0 : timestamp - json.samples[i - 1].timestamp,
+    ),
+  } as FileFormat.Profile
+
+  const frames = json.frames.map(f => {
+    return {
+      name: f.name,
+      line: f.line,
+      col: f.column,
+      file: f.resourceId != null ? json.resources[f.resourceId] : '(unknown)',
+    }
+  })
+
+  return {
+    $schema: 'https://www.speedscope.app/file-format-schema.json',
+    shared: {
+      frames,
+    },
+    profiles: [profile],
+  }
+}
+
+export function importFromJSSelfProfiling(serialized: JSSelfProfilingData): ProfileGroup {
+  return importSpeedscopeProfiles(jsspToSpeedscope(serialized))
+}


### PR DESCRIPTION
This adds support for importing data in the format produced by the [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/).

I'm not too familiar with the internals of this project, so I went the cheap route: there's a fairly straightforward mapping from the Self-Profiling data format to the Speedscope SAMPLED file format, so I've done that mapping and delegated to the Speedscope importer to do the rest of the work.