### PR TITLE
Replace fuzzy matching with exact substring matching for finding matching frames

### DIFF
--- a/src/lib/profile-search.test.ts
+++ b/src/lib/profile-search.test.ts
@@ -1,0 +1,50 @@
+import {exactMatchStrings} from './profile-search'
+
+function assertMatch(text: string, pattern: string, expected: string) {
+  const match = exactMatchStrings(text, pattern)
+
+  let highlighted = ''
+  let last = 0
+  for (let range of match) {
+    highlighted += `${text.slice(last, range[0])}[${text.slice(range[0], range[1])}]`
+    last = range[1]
+  }
+  highlighted += text.slice(last)
+
+  expect(highlighted).toEqual(expected)
+}
+
+function assertNoMatch(text: string, pattern: string) {
+  assertMatch(text, pattern, text)
+}
+
+describe('exactMatchStrings', () => {
+  test('no match', () => {
+    assertNoMatch('a', 'b')
+    assertNoMatch('aa', 'ab')
+    assertNoMatch('a', 'aa')
+    assertNoMatch('ca', 'ac')
+  })
+
+  test('full text match', () => {
+    assertMatch('hello', 'hello', '[hello]')
+    assertMatch('multiple words', 'multiple words', '[multiple words]')
+  })
+
+  test('case sensitivity', () => {
+    assertMatch('HELLO', 'hello', '[HELLO]')
+    assertMatch('Hello', 'hello', '[Hello]')
+    assertMatch('hello', 'Hello', '[hello]')
+    assertMatch('hello', 'HELLO', '[hello]')
+  })
+
+  test('multiple occurrences', () => {
+    assertMatch('hello hello', 'hello', '[hello] [hello]')
+    assertMatch('hellohello', 'hello', '[hello][hello]')
+  })
+
+  test('overlapping occurrences', () => {
+    assertMatch('aaaaa', 'aa', '[aa][aa]a')
+    assertMatch('abababa', 'aba', '[aba]b[aba]')
+  })
+})

--- a/src/views/flamechart-pan-zoom-view.tsx
+++ b/src/views/flamechart-pan-zoom-view.tsx
@@ -241,7 +241,7 @@ export class FlamechartPanZoomView extends Component<FlamechartPanZoomViewProps,
           if (match) {
             const rangesToHighlightInTrimmedText = remapRangesToTrimmedText(
               trimmedText,
-              match.matchedRanges,
+              match
             )
 
             // Once we have the character ranges to highlight, we need to

--- a/src/views/profile-table-view.tsx
+++ b/src/views/profile-table-view.tsx
@@ -217,7 +217,7 @@ export const ProfileTableView = memo(
           rows.push(
             ProfileTableRowView({
               frame,
-              matchedRanges: match == null ? null : match.matchedRanges,
+              matchedRanges: match == null ? null : match,
               index: i,
               profile: profile,
               selectedFrame: selectedFrame,

--- a/src/views/sandwich-view.tsx
+++ b/src/views/sandwich-view.tsx
@@ -11,7 +11,6 @@ import {SandwichSearchView} from './sandwich-search-view'
 import {ActiveProfileState} from '../app-state/active-profile-state'
 import {sortBy} from '../lib/utils'
 import {ProfileSearchContext} from './search-view'
-import {FuzzyMatch} from '../lib/fuzzy-find'
 import {Theme, useTheme, withTheme} from './themes/theme'
 import {SortField, SortDirection, profileGroupAtom, tableSortMethodAtom} from '../app-state'
 import {useAtom} from '../lib/atom'
@@ -141,7 +140,7 @@ interface SandwichViewContextData {
   selectedFrame: Frame | null
   setSelectedFrame: (frame: Frame | null) => void
   getIndexForFrame: (frame: Frame) => number | null
-  getSearchMatchForFrame: (frame: Frame) => FuzzyMatch | null
+  getSearchMatchForFrame: (frame: Frame) => [number, number][] | null
 }
 
 export const SandwichViewContext = createContext<SandwichViewContextData | null>(null)
@@ -204,7 +203,7 @@ export const SandwichViewContainer = memo((ownProps: SandwichViewContainerProps)
     }
   }, [rowList])
 
-  const getSearchMatchForFrame: (frame: Frame) => FuzzyMatch | null = useMemo(() => {
+  const getSearchMatchForFrame: (frame: Frame) => [number, number][] | null = useMemo(() => {
     return (frame: Frame) => {
       if (profileSearchResults == null) return null
       return profileSearchResults.getMatchForFrame(frame)


### PR DESCRIPTION
In #297, I re-used the fuzzy matching logic I implemented in #282 for profile selection. Based on feedback from several people in #352, this is surprising behavior.

Upon reflection, this should have been obvious -- I hijacked the Ctrl/Cmd+F browser behaviour, so I should try to replicate the expected behaviour there as closely as possible. Given more patience, I also would've done some user research :)

This PR updates this logic to try to more closely match browser behaviour. This means case-insensitive, exact-substring matching.

I've left the fuzzy matching alone for profile selection since that doesn't attempt to mimic browser behaviour.

The non-fuzzy matching feels slightly odd to me given the filtering behaviour on the sandwich view, but I think consistency across this find UI is important.

Here are the before & after results when searching for the string "ca" in the example profile.

|Before|After|
|-|-|
|<img width="1791" alt="image" src="https://user-images.githubusercontent.com/150329/197232741-6d1d7a8a-8b8c-4a4f-98e3-2c043fd7efd5.png">|<img width="1789" alt="image" src="https://user-images.githubusercontent.com/150329/197232694-82697b68-ca15-49e7-887b-2606646ee5e9.png">|


Fixes #352 
Supersedes #403 