### PR TITLE
Update package.json to use upstream version of uint8array-json-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "speedscope",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.13.0",
+      "name": "speedscope",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "open": "7.2.0"
@@ -38,7 +39,7 @@
         "typescript": "4.2.3",
         "typescript-json-schema": "0.42.0",
         "uglify-es": "3.2.2",
-        "uint8array-json-parser": "jlfwong/uint8array-json-parser#edce51ce"
+        "uint8array-json-parser": "0.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5843,6 +5844,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
       "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -14095,10 +14097,10 @@
       }
     },
     "node_modules/uint8array-json-parser": {
-      "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/jlfwong/uint8array-json-parser.git#b4eb100aa3107b5829980171e1dee7d8bf35afe2",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/uint8array-json-parser/-/uint8array-json-parser-0.0.2.tgz",
+      "integrity": "sha512-Cp5ycrI17rzdAkybRfZydr6XdLmOUfhm2jS1i35p3UY2G8TcT7fL+hmFY3zjMGNtoS8uSpdTS7NjiHh+LY/7Bg==",
+      "dev": true
     },
     "node_modules/uncss": {
       "version": "0.17.3",
@@ -26921,9 +26923,10 @@
       }
     },
     "uint8array-json-parser": {
-      "version": "git+ssh://git@github.com/jlfwong/uint8array-json-parser.git#b4eb100aa3107b5829980171e1dee7d8bf35afe2",
-      "dev": true,
-      "from": "uint8array-json-parser@jlfwong/uint8array-json-parser#edce51ce"
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/uint8array-json-parser/-/uint8array-json-parser-0.0.2.tgz",
+      "integrity": "sha512-Cp5ycrI17rzdAkybRfZydr6XdLmOUfhm2jS1i35p3UY2G8TcT7fL+hmFY3zjMGNtoS8uSpdTS7NjiHh+LY/7Bg==",
+      "dev": true
     },
     "uncss": {
       "version": "0.17.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "4.2.3",
     "typescript-json-schema": "0.42.0",
     "uglify-es": "3.2.2",
-    "uint8array-json-parser": "jlfwong/uint8array-json-parser#edce51ce"
+    "uint8array-json-parser": "0.0.2"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
In #385, I introduced a dependency on the `uint8array-json-parser` npm package, but used a fork because of a typescript error. This was resolved in evanw/uint8array-json-parser#1 and published as part of `uint8array-json-parser@0.0.2`. Let's use the upstream.

This also conveniently fixes a new typechecking error that was preventing deployment. The error looked like this:

```
src/import/utils.ts(2,26): error TS2306: File '\''/Users/jlfwong/code/speedscope/node_modules/uint8array-json-parser/uint8array-json-parser.ts'\'' is not a module.'
```

After updating to the upstream, the problem is fixed.