### PR TITLE
Bundle the font

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>speedscope</title>
-  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet">
+  <link href="source-code-pro.css" rel="stylesheet">
   <script>
     // https://github.com/evanw/webgl-recorder
     false && (function () {

--- a/assets/source-code-pro.css
+++ b/assets/source-code-pro.css
@@ -1,0 +1,7 @@
+@font-face{
+	font-family: 'Source Code Pro';
+	font-weight: 400;
+	font-style: normal;
+	font-stretch: normal;
+	src: url('../node_modules/source-code-pro/TTF/SourceCodePro-Regular.ttf') format('truetype');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "preact": "10.4.1",
         "prettier": "2.0.4",
         "protobufjs": "6.8.8",
+        "source-code-pro": "2.38.0",
         "source-map": "0.6.1",
         "ts-jest": "24.3.0",
         "typescript": "4.2.3",
@@ -4473,6 +4474,7 @@
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
       "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^1.7.1"
@@ -12454,6 +12456,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/source-code-pro": {
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/source-code-pro/-/source-code-pro-2.38.0.tgz",
+      "integrity": "sha512-JMXu7l3XrLREG17eEwY66ANG9716WTu6OeNvZfRKQKANEvbSERDZjk5AYTHeV6owQNPQTeiiW3ri2Ou93XFGvg==",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -25569,6 +25577,12 @@
       "requires": {
         "kind-of": "^3.2.0"
       }
+    },
+    "source-code-pro": {
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/source-code-pro/-/source-code-pro-2.38.0.tgz",
+      "integrity": "sha512-JMXu7l3XrLREG17eEwY66ANG9716WTu6OeNvZfRKQKANEvbSERDZjk5AYTHeV6owQNPQTeiiW3ri2Ou93XFGvg==",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "preact": "10.4.1",
     "prettier": "2.0.4",
     "protobufjs": "6.8.8",
+    "source-code-pro": "2.38.0",
     "source-map": "0.6.1",
     "ts-jest": "24.3.0",
     "typescript": "4.2.3",


### PR DESCRIPTION
For performance, offline support and privacy.

Cut down the CSS file from the package so that we only need to bundle
the one font file, like what Google was doing.
