### PR TITLE
Fix out of bounds error for pprof default type

### DIFF
--- a/src/import/pprof.ts
+++ b/src/import/pprof.ts
@@ -104,8 +104,11 @@ export function importAsPprofProfile(rawProfile: ArrayBuffer): Profile | null {
   }))
 
   const sampleTypeIndex = protoProfile.defaultSampleType
-    ? +protoProfile.defaultSampleType
+    ? +protoProfile.defaultSampleType > sampleTypes.length - 1
+      ? sampleTypes.length - 1
+      : +protoProfile.defaultSampleType
     : sampleTypes.length - 1
+
   const sampleType = sampleTypes[sampleTypeIndex]
 
   const profileBuilder = new StackListProfileBuilder()


### PR DESCRIPTION
It is possible that the defaultSampleType index is out of bounds. This adds a bounds check to ensure it is a valid index.