### PR TITLE
Fix trimTextMid

### DIFF
--- a/src/lib/text-utils.ts
+++ b/src/lib/text-utils.ts
@@ -43,8 +43,8 @@ export function buildTrimmedText(text: string, length: number): TrimmedTextResul
 
   let prefixLength = Math.floor(length / 2)
   const suffixLength = length - prefixLength - 1
-  const prefix = text.substr(0, prefixLength)
-  const suffix = text.substr(text.length - suffixLength, suffixLength)
+  const prefix = text.substring(0, prefixLength)
+  const suffix = text.substring(text.length - suffixLength, text.length)
   const trimmedString = prefix + ELLIPSIS + suffix
   return {
     trimmedString,
@@ -69,11 +69,11 @@ export function trimTextMid(
     0,
     text.length,
     n => {
-      return cachedMeasureTextWidth(ctx, buildTrimmedText(text, n).trimmedString)
+      return cachedMeasureTextWidth(ctx, buildTrimmedText(text, Math.floor(n)).trimmedString)
     },
     maxWidth,
   )
-  return buildTrimmedText(text, lo)
+  return buildTrimmedText(text, Math.floor(lo))
 }
 
 enum IndexTypeInTrimmed {


### PR DESCRIPTION
There was a subtle bug in `trimTextMid` caused by calling substring methods with non-integer values. This happens because `findValueBisect` returns non-integer values, and there was no special handling of this.

The bug results in strings cutting off many of the last few characters in a string, rather than always displaying it when possible.

Before:
<img width="368" alt="image" src="https://github.com/jlfwong/speedscope/assets/150329/754a25f1-a6f7-46f1-8e34-059503d9e4cf">

After:
<img width="386" alt="image" src="https://github.com/jlfwong/speedscope/assets/150329/b2688ca1-54af-4d2e-b704-9f3322d2e5b4">

Fixes #411 