### PR TITLE
Improve splitLines: return iterator instead

### DIFF
--- a/src/import/callgrind.ts
+++ b/src/import/callgrind.ts
@@ -346,7 +346,7 @@ class CallgrindParser {
   private savedFunctionNames: {[id: string]: string} = {}
 
   constructor(contents: TextFileContent, private importedFileName: string) {
-    this.lines = contents.splitLines()
+    this.lines = [...contents.splitLines()]
     this.lineNum = 0
   }
 

--- a/src/import/instruments.ts
+++ b/src/import/instruments.ts
@@ -14,7 +14,7 @@ import {FileSystemDirectoryEntry, FileSystemEntry, FileSystemFileEntry} from './
 import {MaybeCompressedDataReader, TextFileContent} from './utils'
 
 function parseTSV<T>(contents: TextFileContent): T[] {
-  const lines = contents.splitLines().map(l => l.split('\t'))
+  const lines = [...contents.splitLines()].map(l => l.split('\t'))
 
   const headerLine = lines.shift()
   if (!headerLine) return []

--- a/src/import/papyrus.ts
+++ b/src/import/papyrus.ts
@@ -38,9 +38,9 @@ export function importFromPapyrus(papyrusProfile: TextFileContent): Profile {
   const profile = new CallTreeProfileBuilder()
   profile.setValueFormatter(new TimeFormatter('milliseconds'))
 
-  const papyrusProfileLines = papyrusProfile
-    .splitLines()
-    .filter(line => !/^$|^Log closed$|log opened/.exec(line))
+  const papyrusProfileLines = [...papyrusProfile.splitLines()].filter(
+    line => !/^$|^Log closed$|log opened/.exec(line),
+  )
 
   let startValue = -1
   const firstLineParsed = parseLine(papyrusProfileLines[0])

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -247,11 +247,18 @@ test('BufferBackedTextFileContent.firstChunk', async () => {
 })
 
 test('BufferBackedTextFileContent.splitLines', async () => {
-  await withMockedFileChunkSizeForTests(2, () => {
-    const str = 'may\nyour\nrope\nbe\nlong'
+  function testWithString(str: string) {
     const buffer = new TextEncoder().encode(str).buffer
     const content = new BufferBackedTextFileContent(buffer)
-    expect(content.splitLines()).toEqual(['may', 'your', 'rope', 'be', 'long'])
+    expect([...content.splitLines()]).toEqual(str.split('\n'))
+  }
+
+  await withMockedFileChunkSizeForTests(2, () => {
+    testWithString('may\nyour\nrope\nbe\nlong')
+    testWithString('one-single-line')
+    testWithString('multiple\n\nnew\n\nlines')
+    testWithString('end-with-new-line\n')
+    testWithString('')
   })
 })
 


### PR DESCRIPTION
The current behavior of splitLines is to eagerly split all the lines and return an array of strings.

This PR improves this by returning an iterator instead, which will emit lines. This lets callers decide how to best use the splitLines function (i.e. lazily enumerate over lines)

Relates to #433