### PR TITLE
Improve profile builder performance

### DIFF
--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -439,14 +439,13 @@ export class Profile {
 }
 
 export class StackListProfileBuilder extends Profile {
-  _appendSample(stack: FrameInfo[], weight: number, useAppendOrder: boolean) {
+  _appendSample(stack: Frame[], weight: number, useAppendOrder: boolean) {
     if (isNaN(weight)) throw new Error('invalid weight')
     let node = useAppendOrder ? this.appendOrderCalltreeRoot : this.groupedCalltreeRoot
 
     let framesInStack = new Set<Frame>()
 
-    for (let frameInfo of stack) {
-      const frame = Frame.getOrInsert(this.frames, frameInfo)
+    for (let frame of stack) {
       const last = useAppendOrder
         ? lastOf(node.children)
         : node.children.find(c => c.frame === frame)
@@ -500,8 +499,9 @@ export class StackListProfileBuilder extends Profile {
       throw new Error('Samples must have positive weights')
     }
 
-    this._appendSample(stack, weight, true)
-    this._appendSample(stack, weight, false)
+    const frames = stack.map(fr => Frame.getOrInsert(this.frames, fr))
+    this._appendSample(frames, weight, true)
+    this._appendSample(frames, weight, false)
   }
 
   private pendingSample: {


### PR DESCRIPTION
Follow up on this PR #435. 

Currently, it took roughly 22 seconds to load my 1.3GB file. After inspecting the profiler, there's a large chunk of time spending in Frame.getOrInsert. I figure we can reduce the number of invocations by half. It reduces the load time to roughly 18 seconds.I also tested with a smaller file (~350MB), and it show similar gains, about 15-20%

I know this is not a proper way to perform benchmarking, and also I'm clueless about the impact on other file formats/sizes. So I'll leave the judgement to you