### PR TITLE
Increase tooltip hover offset to avoid being obscured by mouse

### DIFF
--- a/src/views/hovertip.tsx
+++ b/src/views/hovertip.tsx
@@ -18,7 +18,7 @@ export function Hovertip(props: HovertipProps) {
   const containerWidth = containerSize.x
   const containerHeight = containerSize.y
 
-  const OFFSET_FROM_MOUSE = 7
+  const OFFSET_FROM_MOUSE = 20
 
   const updateLocation = useCallback((el: HTMLDivElement | null) => {
     if (!el) return


### PR DESCRIPTION
Fixes #444

For context: the default cursor on Windows 10 is 16px wide. Most OSes allow you to make it much bigger so there's not necessarily a 'right' value here, but it feels sensible to at least avoid obscuring it when using defaults.

Given most cursors display _below_ the pixel at which the cursor is pointing, a solution which works in more cases would probably need to make a change from the current decision to `// Place the tooltip below the cursor` but for now I have avoided doing this (I'm not sure of the historical reasons) and instead done the minimal improvement.