### PR TITLE
Re-enable eslint prettier rule after being accidentally disabled for 3 years

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
   plugins: ['prettier', '@typescript-eslint', 'react-hooks'],
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
+    'prettier/prettier': 'error',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': [
       'error',

--- a/src/import/trace-event.ts
+++ b/src/import/trace-event.ts
@@ -329,10 +329,7 @@ function getProfileNameByPidTid(
   return profileNamesByPidTid
 }
 
-function eventListToProfile(
-  importableEvents: ImportableTraceEvent[],
-  name: string,
-): Profile {
+function eventListToProfile(importableEvents: ImportableTraceEvent[], name: string): Profile {
   // The trace event format is hard to deal with because it specifically
   // allows events to be recorded out of order, *but* event ordering is still
   // important for events with the same timestamp. Because of this, rather
@@ -529,11 +526,7 @@ function getActiveFramesForSample(
   return frames.reverse()
 }
 
-function sampleListToProfile(
-  contents: TraceWithSamples,
-  samples: Sample[],
-  name: string,
-): Profile {
+function sampleListToProfile(contents: TraceWithSamples, samples: Sample[], name: string): Profile {
   const profileBuilder = new StackListProfileBuilder()
 
   profileBuilder.setValueFormatter(new TimeFormatter('microseconds'))
@@ -565,10 +558,7 @@ function eventListToProfileGroup(events: TraceEvent[]): ProfileGroup {
       throw new Error(`Could not find events for key: ${importableEventsForPidTid}`)
     }
 
-    profilePairs.push([
-      profileKey,
-      eventListToProfile(importableEventsForPidTid, name),
-    ])
+    profilePairs.push([profileKey, eventListToProfile(importableEventsForPidTid, name)])
   })
 
   // For now, we just sort processes by pid & tid.
@@ -603,10 +593,7 @@ function sampleListToProfileGroup(contents: TraceWithSamples): ProfileGroup {
       return
     }
 
-    profilePairs.push([
-      profileKey,
-      sampleListToProfile(contents, samplesForPidTid, name),
-    ])
+    profilePairs.push([profileKey, sampleListToProfile(contents, samplesForPidTid, name)])
   })
 
   // For now, we just sort processes by pid & tid.


### PR DESCRIPTION
It looks like in #267 (which was 3 years ago!), I accidentally disabled prettier linting altogether 😱

https://github.com/jlfwong/speedscope/pull/267/files#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5

There's no comment in that PR about this being an intentional thing, so I have to assume this was a dumb mistake.