### PR TITLE
Add hermes-specific support for the trace event format

### DIFF
--- a/sample/profiles/trace-event/simple-hermes.json
+++ b/sample/profiles/trace-event/simple-hermes.json
@@ -1,0 +1,76 @@
+[
+    {
+      "pid": 0,
+      "tid": 0,
+      "ph": "B",
+      "name": "[root]",
+      "ts": 0,
+      "args": {
+        "name": "[root]",
+        "category": "root",
+        "url": null,
+        "line": null,
+        "column": null,
+        "params": null,
+        "allocatedCategory": "root",
+        "allocatedName": "[root]"
+      }
+    },
+    {
+      "pid": 0,
+      "tid": 0,
+      "ph": "B",
+      "name": "beta",
+      "ts": 1,
+      "args": {
+        "line": 54,
+        "column": 12,
+        "funcLine": "1",
+        "funcColumn": "1",
+        "name": "beta",
+        "category": "JavaScript",
+        "parent": 1,
+        "url": "/Users/example/test_project/node_modules/metro-runtime/src/polyfills/require.js",
+        "params": null,
+        "allocatedCategory": "JavaScript",
+        "allocatedName": "beta"
+      }
+    },
+    {
+      "pid": 0,
+      "tid": 0,
+      "ph": "E",
+      "name": "beta",
+      "ts": 13,
+      "args": {
+        "line": 54,
+        "column": 12,
+        "funcLine": "1",
+        "funcColumn": "1",
+        "name": "beta",
+        "category": "JavaScript",
+        "parent": 1,
+        "url": "/Users/example/test_project/node_modules/metro-runtime/src/polyfills/require.js",
+        "params": null,
+        "allocatedCategory": "JavaScript",
+        "allocatedName": "beta"
+      }
+    },
+    {
+      "pid": 0,
+      "tid": 0,
+      "ph": "E",
+      "name": "[root]",
+      "ts": 14,
+      "args": {
+        "name": "[root]",
+        "category": "root",
+        "url": null,
+        "line": null,
+        "column": null,
+        "params": null,
+        "allocatedCategory": "root",
+        "allocatedName": "[root]"
+      }
+    }
+  ]

--- a/src/import/__snapshots__/trace-event.test.ts.snap
+++ b/src/import/__snapshots__/trace-event.test.ts.snap
@@ -1315,6 +1315,41 @@ Object {
 }
 `;
 
+exports[`importTraceEvents simple hermes profile 1`] = `
+Object {
+  "frames": Array [
+    Frame {
+      "col": null,
+      "file": null,
+      "key": "[root] {\\"name\\":\\"[root]\\",\\"category\\":\\"root\\",\\"url\\":null,\\"line\\":null,\\"column\\":null,\\"params\\":null,\\"allocatedCategory\\":\\"root\\",\\"allocatedName\\":\\"[root]\\"}",
+      "line": null,
+      "name": "[root]",
+      "selfWeight": 2,
+      "totalWeight": 14,
+    },
+    Frame {
+      "col": 12,
+      "file": "/Users/example/test_project/node_modules/metro-runtime/src/polyfills/require.js",
+      "key": "beta {\\"line\\":54,\\"column\\":12,\\"funcLine\\":\\"1\\",\\"funcColumn\\":\\"1\\",\\"name\\":\\"beta\\",\\"category\\":\\"JavaScript\\",\\"parent\\":1,\\"url\\":\\"/Users/example/test_project/node_modules/metro-runtime/src/polyfills/require.js\\",\\"params\\":null,\\"allocatedCategory\\":\\"JavaScript\\",\\"allocatedName\\":\\"beta\\"}",
+      "line": 54,
+      "name": "beta",
+      "selfWeight": 12,
+      "totalWeight": 12,
+    },
+  ],
+  "name": "pid 0, tid 0",
+  "stacks": Array [
+    "[root] 1.00µs",
+    "[root];beta 12.00µs",
+    "[root] 1.00µs",
+  ],
+}
+`;
+
+exports[`importTraceEvents simple hermes profile: indexToView 1`] = `0`;
+
+exports[`importTraceEvents simple hermes profile: profileGroup.name 1`] = `"simple-hermes.json"`;
+
 exports[`importTraceEvents simple object 1`] = `
 Object {
   "frames": Array [

--- a/src/import/trace-event.test.ts
+++ b/src/import/trace-event.test.ts
@@ -123,6 +123,10 @@ test('importTraceEvents event reordering name match', async () => {
   await checkProfileSnapshot('./sample/profiles/trace-event/event-reordering-name-match.json')
 })
 
+test('importTraceEvents simple hermes profile', async () => {
+  await checkProfileSnapshot('./sample/profiles/trace-event/simple-hermes.json')
+})
+
 test('importTraceEvents simple profile with samples', async () => {
   await checkProfileSnapshot('./sample/profiles/trace-event/simple-with-samples.json')
 })

--- a/src/import/trace-event.ts
+++ b/src/import/trace-event.ts
@@ -588,8 +588,6 @@ function sampleListToProfile(contents: TraceWithSamples, samples: Sample[], name
 }
 
 function eventListToProfileGroup(events: TraceEvent[], isHermesProfile = false): ProfileGroup {
-  console.log({isHermesProfile})
-
   const importableEvents = filterIgnoredEventTypes(events)
   const partitionedTraceEvents = partitionByPidTid(importableEvents)
   const profileNamesByPidTid = getProfileNameByPidTid(events, partitionedTraceEvents)
@@ -705,13 +703,7 @@ function isHermesTraceEvent(traceEventArgs: any): traceEventArgs is HermesTraceE
     return false
   }
 
-  for (const prop of requiredProperties) {
-    if (!(prop in traceEventArgs)) {
-      return false
-    }
-  }
-
-  return true
+  return requiredProperties.every(prop => prop in traceEventArgs)
 }
 
 function isHermesTraceEventList(maybeEventList: any): maybeEventList is HermesTraceEvent[] {


### PR DESCRIPTION
Profiles that are transformed into the hermes trace event format are guaranteed to have specific arguments that supply metadata that is useful for debugging - namely the filename, line + col number that the function call originated from, with sourcemaps applied. This PR adds specific support for this information to the trace event importer. This means that we can have the Frame name be just the name of the function, since we know all the information we want to be displayed in the UI is captured in the frame info, which makes the traces cleaner to look at.

| Before | After |
|-----|-----|
| <img width="1728" alt="Screenshot 2023-12-26 at 2 40 01 PM" src="https://github.com/jlfwong/speedscope/assets/9957046/f9dff608-5df3-4098-b1f8-91a69185d906"> | <img width="1726" alt="Screenshot 2023-12-26 at 2 39 13 PM" src="https://github.com/jlfwong/speedscope/assets/9957046/b8ff360e-a316-4bef-8ebc-620c9ff1a998"> |
| <img width="1728" alt="Screenshot 2023-12-26 at 2 41 03 PM" src="https://github.com/jlfwong/speedscope/assets/9957046/127a49b5-458e-4ac8-934a-202e565cb20f"> | <img width="1728" alt="Screenshot 2023-12-26 at 2 41 29 PM" src="https://github.com/jlfwong/speedscope/assets/9957046/ebb285ce-6b33-4535-8e45-b9ada4e4d97f"> |