### PR TITLE
Partition based on samples instead of traceEvents when importing a sample-based chrome trace

### DIFF
--- a/sample/profiles/trace-event/simple-with-samples.json
+++ b/sample/profiles/trace-event/simple-with-samples.json
@@ -21,16 +21,6 @@
       "args": {
         "name": "mqt_js"
       }
-    },
-    {
-      "name": "mqt_js",
-      "cat": "mqt_js",
-      "ph": "X",
-      "dur": 0,
-      "pid": 7512,
-      "ts": "11550183666",
-      "tid": "7695",
-      "args": {}
     }
   ],
   "samples": [

--- a/src/import/trace-event.ts
+++ b/src/import/trace-event.ts
@@ -140,7 +140,7 @@ interface TraceEventObject {
 
 type Trace = TraceEvent[] | TraceEventObject | TraceWithSamples
 
-function pidTidKey(pid: number | number, tid: number | number): string {
+function pidTidKey(pid: number, tid: number): string {
   // We zero-pad the PID and TID to make sorting them by pid/tid pair later easier.
   return `${zeroPad('' + pid, 10)}:${zeroPad('' + tid, 10)}`
 }
@@ -349,7 +349,7 @@ function frameInfoForEvent(
   }
 }
 
-function getProfileNameFromPidTid(
+function getProfileName(
   processName: string | undefined,
   threadName: string | undefined,
   pid: number,
@@ -384,7 +384,7 @@ function getProfileNamesFromSamples(
     const profileKey = pidTidKey(pid, tid)
     const processName = processNamesByPid.get(pid)
     const threadName = threadNamesByPidTid.get(profileKey)
-    const profileName = getProfileNameFromPidTid(processName, threadName, pid, tid)
+    const profileName = getProfileName(processName, threadName, pid, tid)
 
     profileNamesByPidTid.set(profileKey, profileName)
   })
@@ -409,7 +409,7 @@ function getProfileNamesFromTraceEvents(
     const profileKey = pidTidKey(pid, tid)
     const processName = processNamesByPid.get(pid)
     const threadName = threadNamesByPidTid.get(profileKey)
-    const profileName = getProfileNameFromPidTid(processName, threadName, pid, tid)
+    const profileName = getProfileName(processName, threadName, pid, tid)
 
     profileNamesByPidTid.set(profileKey, profileName)
   })


### PR DESCRIPTION
In the existing code, if `traceEvents` did not have any importable events, the profile would be marked as empty. This was a bug, as the dev Hermes profiles I was testing with had one X event which made the code work. However we do not need to guarantee (and the spec doesn't seem to) any traceEvents being present as long as we have samples and stack frames. 

When I tested a production profile taken from Hermes it did not have any importable events, just a metadata event with a thread name. This PR updates the implementation to iterate over partitioned samples instead of traceEvents so we construct profiles for all thread + process pairs referenced in the samples array.

| Before | After |
| --- | ----- |
| <img width="1454" alt="Screenshot 2024-01-03 at 9 58 56 AM" src="https://github.com/jlfwong/speedscope/assets/9957046/78c098a7-b374-4492-ad13-9ca79afdb40c"> | <img width="1450" alt="Screenshot 2024-01-03 at 9 58 17 AM" src="https://github.com/jlfwong/speedscope/assets/9957046/d2d5e82b-fa3e-43db-bf8a-e8c3b84cd13a"> |
