### PR TITLE
Allow accept header to be specified alongside profileURL

### DIFF
--- a/src/lib/hash-params.test.ts
+++ b/src/lib/hash-params.test.ts
@@ -22,6 +22,9 @@ test('getHashParams', () => {
   expect(getHashParams('#title=hello%20world')).toEqual({
     title: 'hello world',
   })
+  expect(getHashParams('#profileAccepts=application%2Fjson')).toEqual({
+    profileAccepts: 'application/json',
+  })
   expect(getHashParams('#abc=bcd')).toEqual({})
   expect(getHashParams('garbage')).toEqual({})
 })

--- a/src/lib/hash-params.ts
+++ b/src/lib/hash-params.ts
@@ -2,6 +2,7 @@ import {ViewMode} from '../lib/view-mode'
 
 export interface HashParams {
   profileURL?: string
+  profileAccepts?: string
   title?: string
   localProfilePath?: string
   viewMode?: ViewMode
@@ -36,6 +37,8 @@ export function getHashParams(hashContents = window.location.hash): HashParams {
         result.title = value
       } else if (key === 'localProfilePath') {
         result.localProfilePath = value
+      } else if (key === 'profileAccepts') {
+        result.profileAccepts = value
       } else if (key === 'view') {
         const mode = getViewMode(value)
         if (mode !== null) {

--- a/src/views/application.tsx
+++ b/src/views/application.tsx
@@ -424,7 +424,7 @@ export class Application extends StatelessComponent<ApplicationProps> {
   }
 
   async maybeLoadHashParamProfile() {
-    const {profileURL} = this.props.hashParams
+    const {profileURL, profileAccepts} = this.props.hashParams
     if (profileURL) {
       if (!canUseXHR) {
         alert(
@@ -433,7 +433,14 @@ export class Application extends StatelessComponent<ApplicationProps> {
         return
       }
       this.loadProfile(async () => {
-        const response: Response = await fetch(profileURL)
+        const fetchOpts: RequestInit = {}
+        if (profileAccepts) {
+          fetchOpts['headers'] = {
+            Accept: profileAccepts,
+          }
+        }
+
+        const response: Response = await fetch(profileURL, fetchOpts)
         let filename = new URL(profileURL, window.location.href).pathname
         if (filename.includes('/')) {
           filename = filename.slice(filename.lastIndexOf('/') + 1)


### PR DESCRIPTION
I have an endpoint I'd like to profile that returns HTML or JSON based on the accept header. By default it returns JSON but I'd like to provide a quick link via `profileURL` that will profile the HTML response instead.

Since speedscope doesn't specify an accept header `fetch` defaults to `*/*`, which ends up using the default format of that endpoint. I'd like to be able to specify the accept header explicitly so I can generate quick links to both JSON And HTML profiles.

To solve that ask, this adds a new parameter to the hash based param logic, `profileAccepts` (better name suggestions welcome). This allows you to specify the accept header so that you can explicitly choose which content type to profile when using `#profileURL`.

Usage: `http://localhost:1234/#profileURL=http://mywebsite/page-to-profile&#profileAccepts=application%2Fjson`

I didn't update the README or add any documentation, but happy to if requested!