### PR TITLE
Clarify specification of startValue in speedscope file format

### DIFF
--- a/src/lib/file-format-spec.ts
+++ b/src/lib/file-format-spec.ts
@@ -65,7 +65,7 @@ export namespace FileFormat {
     unit: ValueUnit
 
     // The starting value of the profile. This will typically be a timestamp.
-    // All event values will be relative to this startValue.
+    // All event values will be displayed relative to this startValue.
     startValue: number
 
     // The final value of the profile. This will typically be a timestamp. This
@@ -93,7 +93,7 @@ export namespace FileFormat {
     unit: ValueUnit
 
     // The starting value of the profile. This will typically be a timestamp.
-    // All event values will be relative to this startValue.
+    // All event values will be displayed relative to this startValue.
     startValue: number
 
     // The final value of the profile. This will typically be a timestamp. This


### PR DESCRIPTION
The spec confused me and I'd like to clarify it. Please check that my understanding is correct!

From the commit message:

> The previous description ("event values will be relative to this startValue") was ambiguous.
> 
> Suppose the profile starts at wall time 1000ms and the first event is at wall time 1003ms.
> 
> The intention is that startValue should be set to 1000 and the "at" value of the event should be set to 1003. The viewer's time axis will start at 0ms and the first event will be displayed at 3ms.
> 
> But the previous description could be incorrectly interpreted as saying that the "at" value of the first event should be set to 3 (the time relative to startValue, as opposed to the absolute wall time).
> 
> Clarify that "relative" is referring to how the viewer displays the data, not about which values to store in the file.