### PR TITLE
Update to working `open`, switch to ESM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,19 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm test
         env:
           CI: true
-
+      - name: Try CLI
+        run: node bin/cli.mjs -v
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.node-version }}
@@ -37,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true

--- a/README-ADMINS.md
+++ b/README-ADMINS.md
@@ -21,10 +21,10 @@ cd /var/folders/l0/qtd9z14973s2tw81vmzwkyp00000gp/T/speedscope-test-installation
 
 Run this command, to switch to the test directory.
 
-Inside of here, run `bin/cli.js`. This should open a copy of speedscope in browser.
+Inside of here, run `bin/cli.mjs`. This should open a copy of speedscope in browser.
 Try importing a profile from disk via the browse button and make sure it works.
 
-Next, try running `bin/cli.js dist/release/perf-vertx*`. This should immediately open
+Next, try running `bin/cli.mjs dist/release/perf-vertx*`. This should immediately open
 speedscope in browser, and the perf-vertx file should load immediately.
 
 ## Create & publish the new release

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -93,10 +93,10 @@ async function main() {
     fs.writeFileSync(jsPath, jsSource)
     urlToOpen += `#localProfilePath=${jsPath}`
 
-    // For some silly reason, the OS X open command ignores any query parameters or hash parameters
+    // For some silly reason, the macOS `open` and Windows `start` commands ignore hash parameters
     // passed as part of the URL. To get around this weird issue, we'll create a local HTML file
     // that just redirects.
-    if (process.platform === 'darwin') {
+    if (process.platform === 'darwin' || process.platform === 'win32') {
       const htmlPath = path.join(os.tmpdir(), `${filePrefix}.html`)
       console.log(`Creating temp file ${htmlPath}`)
       fs.writeFileSync(htmlPath, `<script>window.location=${JSON.stringify(urlToOpen)}</script>`)

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -56,7 +56,9 @@ async function main() {
   }
 
   if (process.argv.includes('--version') || process.argv.includes('-v')) {
-    console.log('v' + require('../package.json').version)
+    const json = fs.readFileSync(path.resolve(__dirname, '../package.json'), { encoding: 'utf-8' })
+    const { version } = JSON.parse(json)
+    console.log(`v${version}`)
     return
   }
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
-const path = require('path')
-const fs = require('fs')
-const os = require('os')
-const stream = require('stream')
+import path from 'node:path'
+import fs from 'node:fs'
+import os from 'node:os'
+import stream from 'node:stream'
+import { fileURLToPath } from 'node:url'
 
-const open = require('open')
+import open from 'open'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const helpString = `Usage: speedscope [filepath]
 
@@ -90,11 +94,13 @@ async function main() {
     // For some silly reason, the OS X open command ignores any query parameters or hash parameters
     // passed as part of the URL. To get around this weird issue, we'll create a local HTML file
     // that just redirects.
-    const htmlPath = path.join(os.tmpdir(), `${filePrefix}.html`)
-    console.log(`Creating temp file ${htmlPath}`)
-    fs.writeFileSync(htmlPath, `<script>window.location=${JSON.stringify(urlToOpen)}</script>`)
+    if (process.platform === 'darwin') {
+      const htmlPath = path.join(os.tmpdir(), `${filePrefix}.html`)
+      console.log(`Creating temp file ${htmlPath}`)
+      fs.writeFileSync(htmlPath, `<script>window.location=${JSON.stringify(urlToOpen)}</script>`)
 
-    urlToOpen = `file://${htmlPath}`
+      urlToOpen = `file://${htmlPath}`
+    }
   }
 
   console.log('Opening', urlToOpen, 'in your default browser')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.22.0",
       "license": "MIT",
       "dependencies": {
-        "open": "7.2.0"
+        "open": "10.1.0"
       },
       "bin": {
-        "speedscope": "bin/cli.js"
+        "speedscope": "bin/cli.mjs"
       },
       "devDependencies": {
         "@types/jest": "22.2.3",
@@ -3617,7 +3617,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -6119,6 +6118,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
       "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+      "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -6178,7 +6178,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -6196,7 +6195,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -7937,26 +7935,91 @@
       }
     },
     "node_modules/open": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.2.0.tgz",
-      "integrity": "sha512-4HeyhxCvBTI5uBePsAdi55C5fmqnWZ2e2MlmvWi5KW5tdH5rxoiv/aMtbeVxKZc3eWkT1GymMnLG8XC4Rq4TDQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "license": "MIT",
       "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/open/node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
       "dependencies": {
-        "is-docker": "^2.0.0"
+        "is-inside-container": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -13519,8 +13582,7 @@
     "define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="
     },
     "define-properties": {
       "version": "1.1.2",
@@ -15516,7 +15578,8 @@
     "is-docker": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -15555,7 +15618,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
       "requires": {
         "is-docker": "^3.0.0"
       },
@@ -15563,8 +15625,7 @@
         "is-docker": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-          "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-          "dev": true
+          "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="
         }
       }
     },
@@ -17024,21 +17085,50 @@
       }
     },
     "open": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.2.0.tgz",
-      "integrity": "sha512-4HeyhxCvBTI5uBePsAdi55C5fmqnWZ2e2MlmvWi5KW5tdH5rxoiv/aMtbeVxKZc3eWkT1GymMnLG8XC4Rq4TDQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
       "requires": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
       },
       "dependencies": {
-        "is-wsl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+        "bundle-name": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+          "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
           "requires": {
-            "is-docker": "^2.0.0"
+            "run-applescript": "^7.0.0"
           }
+        },
+        "default-browser": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+          "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+          "requires": {
+            "bundle-name": "^4.1.0",
+            "default-browser-id": "^5.0.0"
+          }
+        },
+        "default-browser-id": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+          "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA=="
+        },
+        "is-wsl": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+          "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+          "requires": {
+            "is-inside-container": "^1.0.0"
+          }
+        },
+        "run-applescript": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+          "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "jlfwong/speedscope",
   "main": "index.js",
   "bin": {
-    "speedscope": "./bin/cli.js"
+    "speedscope": "./bin/cli.mjs"
   },
   "scripts": {
     "deploy": "./scripts/deploy.sh",
@@ -19,7 +19,7 @@
     "serve": "tsx scripts/dev-server.ts"
   },
   "files": [
-    "bin/cli.js",
+    "bin/cli.mjs",
     "dist/release/**",
     "!*.map"
   ],
@@ -78,6 +78,6 @@
     ]
   },
   "dependencies": {
-    "open": "7.2.0"
+    "open": "10.1.0"
   }
 }


### PR DESCRIPTION
See #498

I regenerated all the autogenerated files, but there was an issue with `demangle.wasm.js`: It *also* generated the `module.exports = Module; module.exports.default = Module` lines for some reason, so I manually deleted them.

If you know how to make it only emit ESM exports and leave out the CommonJS exports, I can add that to the makefile.