### PR TITLE
Add functionality to filter flame graphs by search query

### DIFF
--- a/src/app-state/index.ts
+++ b/src/app-state/index.ts
@@ -14,6 +14,9 @@ export const flattenRecursionAtom = new Atom<boolean>(false, 'flattenRecursion')
 export const searchIsActiveAtom = new Atom<boolean>(false, 'searchIsActive')
 export const searchQueryAtom = new Atom<string>('', 'searchQueryAtom')
 
+// True if the flamechart should only show the matching frames when searching.
+export const onlyMatchesAtom = new Atom<boolean>(false, 'onlyMatches')
+
 // Which top-level view should be displayed
 export const viewModeAtom = new Atom<ViewMode>(ViewMode.CHRONO_FLAME_CHART, 'viewMode')
 

--- a/src/lib/profile-search.ts
+++ b/src/lib/profile-search.ts
@@ -42,6 +42,7 @@ export class ProfileSearchResults {
   constructor(
     readonly profile: Profile,
     readonly searchQuery: string,
+    readonly onlyMatches: boolean,
   ) {}
 
   private matches: Map<Frame, [number, number][] | null> | null = null

--- a/src/views/flamechart-search-view.tsx
+++ b/src/views/flamechart-search-view.tsx
@@ -10,6 +10,8 @@ import {Rect, Vec2} from '../lib/math'
 import {h, createContext, ComponentChildren} from 'preact'
 import {Flamechart} from '../lib/flamechart'
 import {CallTreeNode} from '../lib/profile'
+import {useAtom} from '../lib/atom'
+import {onlyMatchesAtom} from '../app-state'
 
 export const FlamechartSearchContext = createContext<FlamechartSearchData | null>(null)
 
@@ -65,6 +67,7 @@ export const FlamechartSearchContextProvider = ({
 
 export const FlamechartSearchView = memo(() => {
   const flamechartData = useContext(FlamechartSearchContext)
+  const onlyMatches = useAtom(onlyMatchesAtom)
 
   // TODO(jlfwong): This pattern is pretty gross, but I really don't want values
   // that can be undefined or null.
@@ -83,6 +86,10 @@ export const FlamechartSearchView = memo(() => {
     if (selectedNode == null) return null
     return searchResults.indexOf(selectedNode)
   }, [searchResults, selectedNode])
+
+  const toggleOnlyMatches = useCallback(() => {
+    onlyMatchesAtom.set(!onlyMatches)
+  }, [onlyMatches])
 
   const selectAndZoomToMatch = useCallback(
     (match: FlamechartSearchMatch) => {
@@ -146,6 +153,7 @@ export const FlamechartSearchView = memo(() => {
       numResults={numResults}
       selectPrev={selectPrev}
       selectNext={selectNext}
+      toggleOnlyMatches={toggleOnlyMatches}
     />
   )
 })

--- a/src/views/sandwich-search-view.tsx
+++ b/src/views/sandwich-search-view.tsx
@@ -39,6 +39,7 @@ export const SandwichSearchView = memo(() => {
       numResults={numResults}
       selectPrev={selectPrev}
       selectNext={selectNext}
+      toggleOnlyMatches={null}
     />
   )
 })

--- a/src/views/search-view.tsx
+++ b/src/views/search-view.tsx
@@ -7,7 +7,7 @@ import {ProfileSearchResults} from '../lib/profile-search'
 import {Profile} from '../lib/profile'
 import {useActiveProfileState} from '../app-state/active-profile-state'
 import {useTheme, withTheme} from './themes/theme'
-import {searchIsActiveAtom, searchQueryAtom} from '../app-state'
+import {searchIsActiveAtom, onlyMatchesAtom, searchQueryAtom} from '../app-state'
 import {useAtom} from '../lib/atom'
 
 function stopPropagation(ev: Event) {
@@ -21,13 +21,14 @@ export const ProfileSearchContextProvider = ({children}: {children: ComponentChi
   const profile: Profile | null = activeProfileState ? activeProfileState.profile : null
   const searchIsActive = useAtom(searchIsActiveAtom)
   const searchQuery = useAtom(searchQueryAtom)
+  const onlyMatches = useAtom(onlyMatchesAtom)
 
   const searchResults = useMemo(() => {
     if (!profile || !searchIsActive || searchQuery.length === 0) {
       return null
     }
-    return new ProfileSearchResults(profile, searchQuery)
-  }, [searchIsActive, searchQuery, profile])
+    return new ProfileSearchResults(profile, searchQuery, onlyMatches)
+  }, [searchIsActive, searchQuery, profile, onlyMatches])
 
   return (
     <ProfileSearchContext.Provider value={searchResults}>{children}</ProfileSearchContext.Provider>
@@ -39,10 +40,11 @@ interface SearchViewProps {
   numResults: number | null
   selectNext: () => void
   selectPrev: () => void
+  toggleOnlyMatches: (() => void) | null
 }
 
 export const SearchView = memo(
-  ({numResults, resultIndex, selectNext, selectPrev}: SearchViewProps) => {
+  ({numResults, resultIndex, selectNext, selectPrev, toggleOnlyMatches}: SearchViewProps) => {
     const theme = useTheme()
     const style = getStyle(theme)
     const searchIsActive = useAtom(searchIsActiveAtom)
@@ -157,6 +159,11 @@ export const SearchView = memo(
             <button className={css(style.icon, style.button)} onClick={selectNext}>
               ➡️
             </button>
+            {toggleOnlyMatches && (
+              <button className={css(style.icon, style.button)} onClick={toggleOnlyMatches}>
+                🎯
+              </button>
+            )}
           </Fragment>
         )}
         <svg


### PR DESCRIPTION
Adds a 🎯 button to the ctrl+f search bar that toggles an 'exact match' filter mode -- it only shows frames that exactly match the search query.

https://github.com/user-attachments/assets/43b0d5ea-373f-41c9-a463-348998eacc91

This is one possible implementation for https://github.com/jlfwong/speedscope/issues/192

The use case I was trying to support (for myself), was the ability to simplify large call graphs into first party code vs specific third party libraries. Seems to kind of relate to the following issues as well
- https://github.com/jlfwong/speedscope/issues/246
- https://github.com/jlfwong/speedscope/issues/468

Filtering the profile on keystroke feels like a fairly expensive operation, but I wasn't sure how else to implement. My fork solves my use case, but would be nice upstream if you'd accept this patch or a similar variant. 