### PR TITLE
fix source-map import on node v14.13+

### DIFF
--- a/src/lib/js-source-map.ts
+++ b/src/lib/js-source-map.ts
@@ -30,7 +30,7 @@ export async function importJavaScriptSourceMapSymbolRemapper(
 
   try {
     contents = JSON.parse(contentsString)
-    consumer = new sourceMap.SourceMapConsumer(contents!)
+    consumer = new sourceMap.default.SourceMapConsumer(contents!)
   } catch (e) {
     return null
   }
@@ -53,7 +53,7 @@ export async function importJavaScriptSourceMapSymbolRemapper(
 
     // We're going to binary search through these later, so make sure they're
     // sorted by their order in the generated file.
-    sourceMap.SourceMapConsumer.GENERATED_ORDER,
+    sourceMap.default.SourceMapConsumer.GENERATED_ORDER,
   )
 
   const sourceMapFileNameWithoutExt = sourceMapFileName.replace(/\.[^/]*$/, '')


### PR DESCRIPTION
`source-map` is a CommonJS module, and [since Node v14.13](https://nodejs.org/api/esm.html#interoperability-with-commonjs), when importing a CommonJS module from an ECMAScript Module, the CommonJS named exports are added to a `default` namespace.

Verified fix by:
1. Drag in the `sample/profiles/source-maps/chrome-85-esbuild.json`
2. Then drag in the `sample/profiles/source-maps/esbuild/typescript-source-map-test.js.map`

Before, it gives "Unrecognized format" error, after, it remaps the files to alpha.ts, gamma.ts, etc. Tested on Node v22.14.0.