### PR TITLE
add envvar for dev server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ via npm:
 
 Invoking `speedscope /path/to/profile` will load speedscope in your default browser.
 
+## Development server
+
+You can run Speedscope as a local server:
+
+    npm run serve
+
+This will bind to http://localhost:8000 by default. To use a different port, set the `SPEEDSCOPE_PORT` enviroment variable.
+
 ## Self-contained directory
 
 If you don't have npm or node installed, you can also download a

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -30,8 +30,10 @@ async function main() {
 
   await ctx.rebuild()
 
-  let {host, port} = await ctx.serve({
+  const port = process.env.SPEEDSCOPE_PORT ? parseInt(process.env.SPEEDSCOPE_PORT) : 8000
+  let {host} = await ctx.serve({
     servedir: outdir,
+    port,
   })
 
   console.log(`Server is running at http://${host}:${port}`)


### PR DESCRIPTION
This change allows the development server to use a different port than the default (8000).

This PR uses `SPEEDSCOPE_PORT` as the envvar name. It is conventional to use `PORT` for most server frameworks, but since Speedscope has been around for a while, it may be safer to use an envvar name that is unlikely to have be used for something other purpose.