### PR TITLE
Compare floats with margin of error to avoid infinite recurrence 

### DIFF
--- a/src/gl/graphics.ts
+++ b/src/gl/graphics.ts
@@ -478,8 +478,9 @@ export namespace WebGL {
       if (
         this._width === widthInPixels &&
         this._height === heightInPixels &&
-        bounds.width === widthInAppUnits &&
-        bounds.height === heightInAppUnits
+        // Compare floats with margin error
+        Math.abs(bounds.width - widthInAppUnits) < 0.02 &&
+        Math.abs(bounds.height - heightInAppUnits) < 0.02
       ) {
         // Nothing to do here!
         return


### PR DESCRIPTION
Chromium-based browsers can report slightly different widths and heights for divs covering the same area, based on used zoom.

For instance, when Speedscope is used with 110% zoom and window size is changed (or redraw is triggered in some other way), the following error is raised, sometimes preventing blocks from being redrawn (the same as in #486):

```
canvas-context.ts:56 Uncaught RangeError: Maximum call stack size exceeded
    at CanvasContext.onBeforeFrame (canvas-context.ts:56:27)
    at graphics.ts:497:46
    at Set.forEach (<anonymous>)
    at Context.resize (graphics.ts:497:32)
    at GLCanvas.maybeResize (application.tsx:107:33)
    at CanvasContext.onBeforeFrame (canvas-context.ts:63:7)
    at graphics.ts:497:46
    at Set.forEach (<anonymous>)
    at Context.resize (graphics.ts:497:32)
    at GLCanvas.maybeResize (application.tsx:107:33)
```

<img width="1881" height="643" alt="image" src="https://github.com/user-attachments/assets/51ab0a01-45f0-4fa1-9ba8-92bb95779525" />

In this PR, a small margin of error is introduced to make sure the recurrence is properly stopped. It potentially fixes #418 and #486.