### PR TITLE
Add error message when WebGL setup fails

### DIFF
--- a/src/views/application-container.tsx
+++ b/src/views/application-container.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact'
 import {getCanvasContext} from '../app-state/getters'
-import {memo, useMemo} from 'preact/compat'
+import {memo, useEffect, useMemo} from 'preact/compat'
 import {useActiveProfileState} from '../app-state/active-profile-state'
 import {useTheme} from './themes/theme'
 import {
@@ -20,10 +20,21 @@ import {Application} from './application'
 export const ApplicationContainer = memo(() => {
   const canvas = useAtom(glCanvasAtom)
   const theme = useTheme()
-  const canvasContext = useMemo(
-    () => (canvas ? getCanvasContext({theme, canvas}) : null),
-    [theme, canvas],
-  )
+  const {canvasContext, error: canvasError} = useMemo(() => {
+    if (!canvas) return {canvasContext: null, error: null}
+    try {
+      return {canvasContext: getCanvasContext({theme, canvas}), error: null}
+    } catch (e) {
+      console.error('Failed to create WebGL context:', e)
+      return {canvasContext: null, error: e}
+    }
+  }, [theme, canvas])
+
+  useEffect(() => {
+    if (canvasError) {
+      errorAtom.set(true)
+    }
+  }, [canvasError])
 
   return (
     <ProfileSearchContextProvider>


### PR DESCRIPTION
I am on Ubuntu 25.10 and for whatever reason,  the normal Google Chrome .deb file that you have to download and install manually does not have webgl enabled (on my machine only? who knows)

The speedscope app doesn't give any user visible error in this case though, so I made it show the default error atom here


<img width="1915" height="1005" alt="image" src="https://github.com/user-attachments/assets/3eaa01f6-0267-4a13-b952-d40c5d5700b4" />


Fixes https://github.com/jlfwong/speedscope/issues/244

BTW huge thank you for speedscope, absolutely great app for performance profiling