### PR TITLE
Add copy summary feature for sharing profile context with LLMs

### DIFF
--- a/src/lib/tree-summary.ts
+++ b/src/lib/tree-summary.ts
@@ -1,0 +1,292 @@
+import {CallTreeNode, Frame} from './profile'
+import {formatPercent} from './utils'
+
+interface TreeSummaryOptions {
+  node: CallTreeNode
+  totalWeight: number
+  formatValue: (v: number) => string
+}
+
+interface TreeLine {
+  indent: string
+  name: string
+  file?: string
+  line?: number
+  col?: number
+  totalWeight: number
+  selfWeight: number
+  totalPercent: number
+  selfPercent: number
+}
+
+// Minimum threshold as a fraction (1%)
+const MIN_WEIGHT_THRESHOLD = 0.01
+
+function buildTreeLines(
+  node: CallTreeNode,
+  totalWeight: number,
+  minWeight: number,
+  lines: TreeLine[],
+  prefix: string,
+  isLast: boolean,
+  isRoot: boolean,
+): void {
+  const {frame} = node
+
+  // Skip the speedscope root node
+  if (node.isRoot()) {
+    // Process children of root directly
+    const children = [...node.children]
+      .filter(child => child.getTotalWeight() >= minWeight)
+      .sort((a, b) => b.getTotalWeight() - a.getTotalWeight())
+    children.forEach((child, index) => {
+      buildTreeLines(child, totalWeight, minWeight, lines, '', index === children.length - 1, true)
+    })
+    return
+  }
+
+  const connector = isRoot ? '' : isLast ? '└─ ' : '├─ '
+  const indent = prefix + connector
+
+  lines.push({
+    indent,
+    name: frame.name,
+    file: frame.file,
+    line: frame.line,
+    col: frame.col,
+    totalWeight: node.getTotalWeight(),
+    selfWeight: node.getSelfWeight(),
+    totalPercent: (node.getTotalWeight() / totalWeight) * 100,
+    selfPercent: (node.getSelfWeight() / totalWeight) * 100,
+  })
+
+  // Sort children by total weight descending, filtering out those below threshold
+  const children = [...node.children]
+    .filter(child => child.getTotalWeight() >= minWeight)
+    .sort((a, b) => b.getTotalWeight() - a.getTotalWeight())
+  const childPrefix = prefix + (isRoot ? '' : isLast ? '   ' : '│  ')
+
+  children.forEach((child, index) => {
+    buildTreeLines(
+      child,
+      totalWeight,
+      minWeight,
+      lines,
+      childPrefix,
+      index === children.length - 1,
+      false,
+    )
+  })
+}
+
+interface BottomsUpEntry {
+  frame: Frame
+  totalWeight: number
+  selfWeight: number
+  totalPercent: number
+  selfPercent: number
+}
+
+/**
+ * Builds the bottoms-up view: a flat list of unique frames in the subtree.
+ * Walks the entire subtree rooted at the given node, aggregating weights per frame.
+ * This is similar to how the sandwich view table works.
+ * Only includes frames whose self weight exceeds minSelfWeight.
+ * Sorted by self weight descending.
+ */
+function buildBottomsUpEntries(
+  node: CallTreeNode,
+  totalWeight: number,
+  minSelfWeight: number,
+): BottomsUpEntry[] {
+  // Map from frame to aggregated weights within this subtree
+  const frameWeights = new Map<Frame, {totalWeight: number; selfWeight: number}>()
+
+  // Walk the subtree and aggregate weights per frame
+  function walkSubtree(n: CallTreeNode): void {
+    if (n.isRoot()) {
+      // Process children of root
+      for (const child of n.children) {
+        walkSubtree(child)
+      }
+      return
+    }
+
+    const frame = n.frame
+    const existing = frameWeights.get(frame)
+    if (existing) {
+      existing.totalWeight += n.getTotalWeight()
+      existing.selfWeight += n.getSelfWeight()
+    } else {
+      frameWeights.set(frame, {
+        totalWeight: n.getTotalWeight(),
+        selfWeight: n.getSelfWeight(),
+      })
+    }
+
+    // Process children
+    for (const child of n.children) {
+      walkSubtree(child)
+    }
+  }
+
+  walkSubtree(node)
+
+  // Convert to entries, filter by self weight, and sort by self weight
+  const entries: BottomsUpEntry[] = []
+  for (const [frame, weights] of frameWeights) {
+    if (weights.selfWeight >= minSelfWeight) {
+      entries.push({
+        frame,
+        totalWeight: weights.totalWeight,
+        selfWeight: weights.selfWeight,
+        totalPercent: (weights.totalWeight / totalWeight) * 100,
+        selfPercent: (weights.selfWeight / totalWeight) * 100,
+      })
+    }
+  }
+
+  // Sort by self weight descending
+  entries.sort((a, b) => b.selfWeight - a.selfWeight)
+
+  return entries
+}
+
+/**
+ * Formats a tree line for output.
+ */
+function formatTreeLine(line: TreeLine, formatValue: (v: number) => string): string[] {
+  const stats = `[${formatValue(line.totalWeight)} (${formatPercent(
+    line.totalPercent,
+  )}), self: ${formatValue(line.selfWeight)} (${formatPercent(line.selfPercent)})]`
+
+  let name = line.name
+  if (line.file) {
+    let location = line.file
+    if (line.line != null) {
+      location += `:${line.line}`
+      if (line.col != null) {
+        location += `:${line.col}`
+      }
+    }
+    name += ` (${location})`
+  }
+
+  return [
+    `${line.indent}${name}`,
+    `${line.indent}${' '.repeat(Math.max(0, name.length - stats.length))}${stats}`,
+  ]
+}
+
+/**
+ * Generates an ASCII tree summary of a call tree node and its descendants.
+ * This is useful for providing performance context to an LLM for analysis.
+ *
+ * Includes two views:
+ * - Call Tree: Shows the tree structure of callees, filtered to nodes >= 1% of the selection's weight
+ * - Bottoms Up: Shows all unique frames in the subtree aggregated by function, filtered/sorted by self weight
+ */
+export function generateTreeSummary(options: TreeSummaryOptions): string {
+  const {node, totalWeight, formatValue} = options
+
+  // Build the output
+  const output: string[] = []
+
+  // Header
+  output.push('Performance Summary')
+  output.push('='.repeat(60))
+  output.push('')
+
+  // Get the node's weight for thresholds
+  const nodeWeight = node.isRoot() ? totalWeight : node.getTotalWeight()
+
+  // Root node info
+  if (!node.isRoot()) {
+    output.push(`Selected: ${node.frame.name}`)
+    if (node.frame.file) {
+      let location = node.frame.file
+      if (node.frame.line != null) {
+        location += `:${node.frame.line}`
+        if (node.frame.col != null) {
+          location += `:${node.frame.col}`
+        }
+      }
+      output.push(`Location: ${location}`)
+    }
+    const totalPercent = (node.getTotalWeight() / totalWeight) * 100
+    const selfPercent = (node.getSelfWeight() / totalWeight) * 100
+    output.push(`Total: ${formatValue(node.getTotalWeight())} (${formatPercent(totalPercent)})`)
+    output.push(`Self: ${formatValue(node.getSelfWeight())} (${formatPercent(selfPercent)})`)
+    output.push('')
+  }
+
+  // Bottoms Up view (all unique frames in subtree, aggregated)
+  // Filter to frames with self weight >= 1% of total profile weight
+  const bottomsUpMinSelfWeight = totalWeight * MIN_WEIGHT_THRESHOLD
+  const bottomsUpEntries = buildBottomsUpEntries(node, totalWeight, bottomsUpMinSelfWeight)
+
+  if (bottomsUpEntries.length > 0) {
+    output.push('Bottoms Up (by self time, >=1% of total):')
+    output.push('-'.repeat(60))
+    output.push('')
+
+    for (const entry of bottomsUpEntries) {
+      let name = entry.frame.name
+      if (entry.frame.file) {
+        let location = entry.frame.file
+        if (entry.frame.line != null) {
+          location += `:${entry.frame.line}`
+          if (entry.frame.col != null) {
+            location += `:${entry.frame.col}`
+          }
+        }
+        name += ` (${location})`
+      }
+      const stats = `[self: ${formatValue(entry.selfWeight)} (${formatPercent(
+        entry.selfPercent,
+      )}), total: ${formatValue(entry.totalWeight)} (${formatPercent(entry.totalPercent)})]`
+      output.push(`${name}`)
+      output.push(`${stats}`)
+      output.push('')
+    }
+  }
+
+  // Call Tree view (children of this node)
+  // Filter to nodes >= 1% of the copied node's weight
+  const callTreeMinWeight = nodeWeight * MIN_WEIGHT_THRESHOLD
+  const callTreeLines: TreeLine[] = []
+  buildTreeLines(node, totalWeight, callTreeMinWeight, callTreeLines, '', true, true)
+
+  if (callTreeLines.length > 0) {
+    output.push('Call Tree (callees, >=1% of selection):')
+    output.push('-'.repeat(60))
+    output.push('')
+
+    for (const line of callTreeLines) {
+      output.push(...formatTreeLine(line, formatValue))
+    }
+    output.push('')
+  }
+
+  if (bottomsUpEntries.length === 0 && callTreeLines.length === 0) {
+    return 'No data available'
+  }
+
+  output.push('-'.repeat(60))
+  output.push(`Total weight of profile: ${formatValue(totalWeight)}`)
+
+  return output.join('\n')
+}
+
+/**
+ * Copies text to the clipboard.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch (err) {
+    console.error('Failed to copy to clipboard:', err)
+    return false
+  }
+}

--- a/src/views/context-menu.tsx
+++ b/src/views/context-menu.tsx
@@ -1,0 +1,114 @@
+import {h, Component, JSX} from 'preact'
+import {css, StyleSheet} from 'aphrodite'
+import {FontSize, FontFamily} from './style'
+import {Theme} from './themes/theme'
+
+export interface ContextMenuItem {
+  label: string
+  onClick: () => void
+}
+
+interface ContextMenuProps {
+  items: ContextMenuItem[]
+  x: number
+  y: number
+  theme: Theme
+  onClose: () => void
+}
+
+interface ContextMenuState {}
+
+export class ContextMenu extends Component<ContextMenuProps, ContextMenuState> {
+  private menuRef: HTMLDivElement | null = null
+
+  componentDidMount() {
+    // Add listeners to close the menu when clicking outside
+    document.addEventListener('mousedown', this.handleClickOutside)
+    document.addEventListener('keydown', this.handleKeyDown)
+    window.addEventListener('blur', this.handleClose)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleClickOutside)
+    document.removeEventListener('keydown', this.handleKeyDown)
+    window.removeEventListener('blur', this.handleClose)
+  }
+
+  private handleClickOutside = (ev: MouseEvent) => {
+    if (this.menuRef && !this.menuRef.contains(ev.target as Node)) {
+      this.props.onClose()
+    }
+  }
+
+  private handleKeyDown = (ev: KeyboardEvent) => {
+    if (ev.key === 'Escape') {
+      this.props.onClose()
+    }
+  }
+
+  private handleClose = () => {
+    this.props.onClose()
+  }
+
+  private handleItemClick = (item: ContextMenuItem) => {
+    item.onClick()
+    this.props.onClose()
+  }
+
+  private getStyle() {
+    const {theme} = this.props
+    return StyleSheet.create({
+      menu: {
+        position: 'fixed',
+        zIndex: 10000,
+        backgroundColor: theme.bgPrimaryColor,
+        border: `1px solid ${theme.fgSecondaryColor}`,
+        borderRadius: 4,
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.25)',
+        padding: '4px 0',
+        minWidth: 180,
+        fontFamily: FontFamily.MONOSPACE,
+        fontSize: FontSize.LABEL,
+      },
+      menuItem: {
+        padding: '6px 12px',
+        cursor: 'pointer',
+        color: theme.fgPrimaryColor,
+        ':hover': {
+          backgroundColor: theme.selectionPrimaryColor,
+          color: theme.altFgPrimaryColor,
+        },
+      },
+    })
+  }
+
+  render() {
+    const {items, x, y} = this.props
+    const style = this.getStyle()
+
+    // Adjust position to keep menu in viewport
+    const menuWidth = 180
+    const menuHeight = items.length * 30 + 8
+    const adjustedX = Math.min(x, window.innerWidth - menuWidth - 10)
+    const adjustedY = Math.min(y, window.innerHeight - menuHeight - 10)
+
+    return (
+      <div
+        ref={el => (this.menuRef = el)}
+        className={css(style.menu)}
+        style={{left: adjustedX, top: adjustedY}}
+      >
+        {items.map((item, index) => (
+          <div
+            key={index}
+            className={css(style.menuItem)}
+            onClick={() => this.handleItemClick(item)}
+          >
+            {item.label}
+          </div>
+        ))}
+      </div>
+    )
+  }
+}
+

--- a/src/views/context-menu.tsx
+++ b/src/views/context-menu.tsx
@@ -1,4 +1,4 @@
-import {h, Component, JSX} from 'preact'
+import {h, Component} from 'preact'
 import {css, StyleSheet} from 'aphrodite'
 import {FontSize, FontFamily} from './style'
 import {Theme} from './themes/theme'
@@ -111,4 +111,3 @@ export class ContextMenu extends Component<ContextMenuProps, ContextMenuState> {
     )
   }
 }
-

--- a/src/views/flamechart-pan-zoom-view.tsx
+++ b/src/views/flamechart-pan-zoom-view.tsx
@@ -73,7 +73,10 @@ interface FlamechartPanZoomViewState {
   } | null
 }
 
-export class FlamechartPanZoomView extends Component<FlamechartPanZoomViewProps, FlamechartPanZoomViewState> {
+export class FlamechartPanZoomView extends Component<
+  FlamechartPanZoomViewProps,
+  FlamechartPanZoomViewState
+> {
   state: FlamechartPanZoomViewState = {
     contextMenu: null,
   }

--- a/src/views/toolbar.tsx
+++ b/src/views/toolbar.tsx
@@ -12,6 +12,7 @@ import {viewModeAtom} from '../app-state'
 import {ProfileGroupState} from '../app-state/profile-group'
 import {colorSchemeAtom} from '../app-state/color-scheme'
 import {useAtom} from '../lib/atom'
+import {generateAllProfilesSummary, copyToClipboard} from '../lib/tree-summary'
 
 interface ToolbarProps extends ApplicationProps {
   browseForFile(): void
@@ -160,6 +161,27 @@ function ToolbarRightContent(props: ToolbarProps) {
   const style = getStyle(useTheme())
   const colorScheme = useAtom(colorSchemeAtom)
 
+  const handleCopySummary = useCallback(async () => {
+    if (!props.profileGroup) return
+
+    const profiles = props.profileGroup.profiles.map(p => ({
+      name: p.profile.getName(),
+      profile: p.profile,
+    }))
+
+    const summary = generateAllProfilesSummary(profiles)
+    const success = await copyToClipboard(summary)
+    if (!success) {
+      console.error('Failed to copy summary to clipboard')
+    }
+  }, [props.profileGroup])
+
+  const copySummary = (
+    <div className={css(style.toolbarTab)} onClick={handleCopySummary}>
+      <span className={css(style.emoji)}>📋</span>Copy Summary
+    </div>
+  )
+
   const exportFile = (
     <div className={css(style.toolbarTab)} onClick={props.saveFile}>
       <span className={css(style.emoji)}>⤴️</span>Export
@@ -194,6 +216,7 @@ function ToolbarRightContent(props: ToolbarProps) {
 
   return (
     <div className={css(style.toolbarRight)}>
+      {props.activeProfileState && copySummary}
       {props.activeProfileState && exportFile}
       {importFile}
       {colorSchemeToggle}


### PR DESCRIPTION
## Summary

- Add a "Copy Summary" button in the toolbar that generates and copies a text summary of all loaded profiles to the clipboard
- Add right-click context menu on flamechart frames with "Copy summary as text" option to copy a summary of a specific node and its callees
- The summaries include both Bottoms Up (by self time) and Call Tree views, filtered to show entries ≥1% of total weight

This makes it easy to share performance profile context with LLMs for analysis.

## Test plan

- [ ] Load a profile, click "Copy Summary" in toolbar, verify text is copied to clipboard
- [ ] Right-click a frame in the flamechart, select "Copy summary as text", verify the summary is specific to that subtree
- [ ] Test with multiple profiles loaded to verify the combined summary works