### PR TITLE
Fix callgrind parser: positions: instr / positions: instr line and cyclic call graphs

### DIFF
--- a/sample/profiles/callgrind/callgrind.cyclic-callgraph.log
+++ b/sample/profiles/callgrind/callgrind.cyclic-callgraph.log
@@ -1,0 +1,20 @@
+# callgrind format
+events: Ir
+
+# funcA calls funcB, funcB calls funcA — fully cyclic, no natural root nodes.
+# The importer must fall back to residual-weight root finding (option 2).
+# funcA residual = 400 - 150 = 250  (positive → root)
+# funcB residual = 200 - 300 = -100 (negative → not a root)
+
+fl=main.c
+fn=funcA
+1 100
+cfn=funcB
+calls=1 10
+10 300
+
+fn=funcB
+10 50
+cfn=funcA
+calls=1 1
+1 150

--- a/sample/profiles/callgrind/callgrind.instr-line-positions.log
+++ b/sample/profiles/callgrind/callgrind.instr-line-positions.log
@@ -1,0 +1,33 @@
+# callgrind format
+positions: instr line
+events: Instructions
+
+fl=file1.c
+fn=main
+0x08048001 16 20
+jfi=file1.c
+jfn=main
+jcnd=2/5 0x08048005 16
+0x08048005 16 3
+jfl=file1.c
+jfn=main
+jump=1 0x08048008 16
+0x08048008 16 1
+cfn=func1
+calls=1 0x08048010 50
+0x08048010 16 400
+cfi=file2.c
+cfn=func2
+calls=3 0x08048020 20
+0x08048020 16 400
+
+fn=func1
+0x08048050 51 100
+cfi=file2.c
+cfn=func2
+calls=2 0x08048060 20
+0x08048060 51 300
+
+fl=file2.c
+fn=func2
+0x08049000 20 700

--- a/sample/profiles/callgrind/callgrind.instr-line-subposition.log
+++ b/sample/profiles/callgrind/callgrind.instr-line-subposition.log
@@ -1,0 +1,25 @@
+# callgrind format
+positions: instr line
+events: Instructions
+
+fl=file1.c
+fn=main
+0x00000100 16 20
+cfn=func1
+calls=1 0x00000200 50
+0x00000200 16 400
+cfi=file2.c
+cfn=func2
+calls=3 0x00000200 20
+* * *
+
+fn=func1
++16 +35 -300
+cfi=file2.c
+cfn=func2
+calls=2 0x00000330 20
++16 * +200
+
+fl=file2.c
+fn=func2
+0x00001000 20 700

--- a/sample/profiles/callgrind/callgrind.positions-instr.log
+++ b/sample/profiles/callgrind/callgrind.positions-instr.log
@@ -1,0 +1,25 @@
+# callgrind format
+positions: instr
+events: Instructions
+
+fl=file1.c
+fn=main
+0x08048001 20
+cfn=func1
+calls=1 0x08048050
+0x08048050 400
+cfi=file2.c
+cfn=func2
+calls=3 0x08049000
+0x08049000 400
+
+fn=func1
+0x08048050 100
+cfi=file2.c
+cfn=func2
+calls=2 0x08049000
+0x08049000 300
+
+fl=file2.c
+fn=func2
+0x08049000 700

--- a/src/import/__snapshots__/callgrind.test.ts.snap
+++ b/src/import/__snapshots__/callgrind.test.ts.snap
@@ -96,6 +96,85 @@ exports[`importFromCallgrind cfn reset: indexToView 1`] = `0`;
 
 exports[`importFromCallgrind cfn reset: profileGroup.name 1`] = `"callgrind.cfn-reset.log"`;
 
+exports[`importFromCallgrind cyclic callgraph 1`] = `
+{
+  "frames": [
+    Frame {
+      "col": undefined,
+      "file": "main.c",
+      "key": "main.c:funcA",
+      "line": undefined,
+      "name": "funcA",
+      "selfWeight": 62,
+      "totalWeight": 250,
+    },
+    Frame {
+      "col": undefined,
+      "file": "main.c",
+      "key": "main.c:funcB",
+      "line": undefined,
+      "name": "funcB",
+      "selfWeight": 188,
+      "totalWeight": 188,
+    },
+  ],
+  "name": "callgrind.cyclic-callgraph.log -- Ir",
+  "stacks": [
+    "funcA;funcB 188",
+    "funcA 62",
+  ],
+}
+`;
+
+exports[`importFromCallgrind cyclic callgraph: indexToView 1`] = `0`;
+
+exports[`importFromCallgrind cyclic callgraph: profileGroup.name 1`] = `"callgrind.cyclic-callgraph.log"`;
+
+exports[`importFromCallgrind instr line subposition compression 1`] = `
+{
+  "frames": [
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:main",
+      "line": undefined,
+      "name": "main",
+      "selfWeight": 20,
+      "totalWeight": 820,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:func1",
+      "line": undefined,
+      "name": "func1",
+      "selfWeight": 100,
+      "totalWeight": 400,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file2.c",
+      "key": "file2.c:func2",
+      "line": undefined,
+      "name": "func2",
+      "selfWeight": 700,
+      "totalWeight": 700,
+    },
+  ],
+  "name": "callgrind.instr-line-subposition.log -- Instructions",
+  "stacks": [
+    "main;func1;func2 300",
+    "main;func1 100",
+    "main;func2 400",
+    "main 20",
+  ],
+}
+`;
+
+exports[`importFromCallgrind instr line subposition compression: indexToView 1`] = `0`;
+
+exports[`importFromCallgrind instr line subposition compression: profileGroup.name 1`] = `"callgrind.instr-line-subposition.log"`;
+
 exports[`importFromCallgrind multiple event types 1`] = `
 {
   "frames": [
@@ -226,6 +305,96 @@ exports[`importFromCallgrind name compression 1`] = `
 exports[`importFromCallgrind name compression: indexToView 1`] = `0`;
 
 exports[`importFromCallgrind name compression: profileGroup.name 1`] = `"callgrind.name-compression.log"`;
+
+exports[`importFromCallgrind positions instr 1`] = `
+{
+  "frames": [
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:main",
+      "line": undefined,
+      "name": "main",
+      "selfWeight": 20,
+      "totalWeight": 820,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:func1",
+      "line": undefined,
+      "name": "func1",
+      "selfWeight": 100,
+      "totalWeight": 400,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file2.c",
+      "key": "file2.c:func2",
+      "line": undefined,
+      "name": "func2",
+      "selfWeight": 700,
+      "totalWeight": 700,
+    },
+  ],
+  "name": "callgrind.positions-instr.log -- Instructions",
+  "stacks": [
+    "main;func1;func2 300",
+    "main;func1 100",
+    "main;func2 400",
+    "main 20",
+  ],
+}
+`;
+
+exports[`importFromCallgrind positions instr line 1`] = `
+{
+  "frames": [
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:main",
+      "line": undefined,
+      "name": "main",
+      "selfWeight": 20,
+      "totalWeight": 820,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file1.c",
+      "key": "file1.c:func1",
+      "line": undefined,
+      "name": "func1",
+      "selfWeight": 100,
+      "totalWeight": 400,
+    },
+    Frame {
+      "col": undefined,
+      "file": "file2.c",
+      "key": "file2.c:func2",
+      "line": undefined,
+      "name": "func2",
+      "selfWeight": 700,
+      "totalWeight": 700,
+    },
+  ],
+  "name": "callgrind.instr-line-positions.log -- Instructions",
+  "stacks": [
+    "main;func1;func2 300",
+    "main;func1 100",
+    "main;func2 400",
+    "main 20",
+  ],
+}
+`;
+
+exports[`importFromCallgrind positions instr line: indexToView 1`] = `0`;
+
+exports[`importFromCallgrind positions instr line: profileGroup.name 1`] = `"callgrind.instr-line-positions.log"`;
+
+exports[`importFromCallgrind positions instr: indexToView 1`] = `0`;
+
+exports[`importFromCallgrind positions instr: profileGroup.name 1`] = `"callgrind.positions-instr.log"`;
 
 exports[`importFromCallgrind subposition compression 1`] = `
 {

--- a/src/import/callgrind.test.ts
+++ b/src/import/callgrind.test.ts
@@ -19,3 +19,19 @@ test('importFromCallgrind subposition compression', async () => {
 test('importFromCallgrind cfn reset', async () => {
   await checkProfileSnapshot('./sample/profiles/callgrind/callgrind.cfn-reset.log')
 })
+
+test('importFromCallgrind positions instr line', async () => {
+  await checkProfileSnapshot('./sample/profiles/callgrind/callgrind.instr-line-positions.log')
+})
+
+test('importFromCallgrind positions instr', async () => {
+  await checkProfileSnapshot('./sample/profiles/callgrind/callgrind.positions-instr.log')
+})
+
+test('importFromCallgrind instr line subposition compression', async () => {
+  await checkProfileSnapshot('./sample/profiles/callgrind/callgrind.instr-line-subposition.log')
+})
+
+test('importFromCallgrind cyclic callgraph', async () => {
+  await checkProfileSnapshot('./sample/profiles/callgrind/callgrind.cyclic-callgraph.log')
+})

--- a/src/import/callgrind.ts
+++ b/src/import/callgrind.ts
@@ -153,11 +153,13 @@ class CallGraph {
 
     const currentStack = new Set<Frame>()
 
+    // Sum of root weights; used as the pruning threshold in visit().
     let maxWeight = 0
-    for (let [_, totalWeight] of this.totalWeights) {
-      maxWeight = Math.max(maxWeight, totalWeight)
-    }
 
+    // Tracks fully-expanded frames; subsequent visits collapse to a leaf to avoid exponential blowup in highly-connected graphs.
+    const visitedGlobally = new Set<Frame>()
+
+    let cycleDetected = false
     const visit = (frame: Frame, subtreeTotalWeight: number) => {
       if (currentStack.has(frame)) {
         // Call-graphs are allowed to have cycles. Call-trees are not. In case
@@ -165,6 +167,7 @@ class CallGraph {
         // more than once in a call stack. The result will be that the time
         // spent in the recursive call will instead be attributed as self time
         // in the parent.
+        cycleDetected = true
         return
       }
 
@@ -218,6 +221,17 @@ class CallGraph {
         return
       }
 
+      // If this frame has already been fully expanded from an earlier call
+      // path, show it as a leaf here (weight becomes self-time) rather than
+      // re-expanding its entire subtree a second time.
+      if (visitedGlobally.has(frame)) {
+        profile.enterFrame(frame, Math.round(totalCumulative * unitMultiplier))
+        totalCumulative += subtreeTotalWeight
+        profile.leaveFrame(frame, Math.round(totalCumulative * unitMultiplier))
+        return
+      }
+      visitedGlobally.add(frame)
+
       let selfWeightForNodeInCallTree = subtreeTotalWeight
 
       profile.enterFrame(frame, Math.round(totalCumulative * unitMultiplier))
@@ -255,7 +269,7 @@ class CallGraph {
     // Here are a few intuitive options, and reasons why they're not always
     // correct or good.
     //
-    // ## 1. Find nodes in the call graph that have no callers
+    // ## 1. (natural-roots) Find nodes in the call graph that have no callers
     //
     // This is probably right 99% of the time in practice, but since the
     // callgrind is totally general, it's totally valid to have a file
@@ -272,7 +286,7 @@ class CallGraph {
     // In this case, even though b has a caller, some of the real calltree for
     // an execution trace of the program will have b on the top of the stack.
     //
-    // ## 2. Find nodes in the call graph that still have weight if you
+    // ## 2. (residual-weight) Find nodes in the call graph that still have weight if you
     //       subtract all of the weight caused by callers.
     //
     // The callgraph format, in theory, provides inclusive times for every
@@ -303,7 +317,8 @@ class CallGraph {
     // a min-heap and then deletes and re-inserts nodes as their weights change,
     // but reasoning about the performance of that is a big pain in the butt.
     //
-    // Despite not always being correct, I'm opting for option (1).
+    // Despite not always being correct, I'm opting for option (1) (natural-roots), with a
+    // fallback to option (2) (residual-weight) when no natural roots exist (e.g. cyclic call graphs).
 
     const rootNodes = new Set<Frame>(this.frameSet)
 
@@ -313,10 +328,46 @@ class CallGraph {
       }
     }
 
-    for (let rootNode of rootNodes) {
-      visit(rootNode, this.totalWeights.get(rootNode)!)
+    let useResidualWeight = false
+    if (rootNodes.size === 0) {
+      useResidualWeight = true
     }
 
+    if (rootNodes.size > 0) {
+      for (let rootNode of rootNodes) {
+        maxWeight += this.totalWeights.get(rootNode)!
+      }
+      for (let rootNode of rootNodes) {
+        visit(rootNode, this.totalWeights.get(rootNode)!)
+      }
+    } else if (useResidualWeight) {
+      // Compute incoming call weights to find residual-weight entry points.
+      const incomingWeights = new Map<Frame, number>()
+      for (const childMap of this.childrenTotalWeights.values()) {
+        for (const [child, weight] of childMap) {
+          incomingWeights.set(child, (incomingWeights.get(child) || 0) + weight)
+        }
+      }
+      const residuals: Array<[Frame, number]> = []
+      for (const [frame, totalWeight] of this.totalWeights) {
+        const residual = totalWeight - (incomingWeights.get(frame) || 0)
+        if (residual > 0) residuals.push([frame, residual])
+      }
+      // Visit heaviest residual roots first so the flame graph is ordered.
+      residuals.sort((a, b) => b[1] - a[1])
+      for (const [, residual] of residuals) {
+        maxWeight += residual
+      }
+      for (const [frame, residual] of residuals) {
+        visit(frame, residual)
+      }
+    }
+
+    if (cycleDetected) {
+      console.warn(
+        `[callgrind] ${this.fileName} (${this.fieldName}): cycle(s) detected in call graph — recursive call weights are attributed as self time in the caller`,
+      )
+    }
     return profile.build()
   }
 }
@@ -334,8 +385,8 @@ class CallGraph {
 // So, instead, I'm not going to bother with a formal parse. Since there are no
 // real recursive structures in this file format, that should be okay.
 class CallgrindParser {
-  private lines: string[]
-  private lineNum: number
+  private lineIterator: Iterator<string>
+  private lineNum: number = 0
 
   private callGraphs: CallGraph[] | null = null
   private eventsLine: string | null = null
@@ -348,17 +399,35 @@ class CallgrindParser {
   private savedFileNames: {[id: string]: string} = {}
   private savedFunctionNames: {[id: string]: string} = {}
 
+  // Tracks the number of position fields per cost line (default 1 = "line" only).
+  // "positions: instr line" means 2 position fields; "positions: instr" means 1.
+  private numPositionFields: number = 1
+
   constructor(
     contents: TextFileContent,
     private importedFileName: string,
   ) {
-    this.lines = [...contents.splitLines()]
-    this.lineNum = 0
+    this.lineIterator = contents.splitLines()[Symbol.iterator]()
   }
 
-  parse(): ProfileGroup | null {
-    while (this.lineNum < this.lines.length) {
-      const line = this.lines[this.lineNum++]
+  private consumeLine(): string | null {
+    const result = this.lineIterator.next()
+    if (result.done) return null
+    this.lineNum++
+    return result.value
+  }
+
+  // Lines parsed per chunk before yielding to the event loop.
+  private static readonly YIELD_EVERY = 10_000
+
+  async parse(): Promise<ProfileGroup | null> {
+    let linesUntilYield = CallgrindParser.YIELD_EVERY
+    let line: string | null
+    while ((line = this.consumeLine()) !== null) {
+      if (--linesUntilYield <= 0) {
+        await new Promise<void>(resolve => setTimeout(resolve, 0))
+        linesUntilYield = CallgrindParser.YIELD_EVERY
+      }
 
       if (/^\s*#/.exec(line)) {
         // Line is a comment. Ignore it.
@@ -412,6 +481,16 @@ class CallgrindParser {
   private parseHeaderLine(line: string): boolean {
     const headerMatch = /^\s*(\w+):\s*(.*)+$/.exec(line)
     if (!headerMatch) return false
+
+    if (headerMatch[1] === 'positions') {
+      // "positions:" declares how many position columns appear before the cost
+      // values on each cost line. Each token is a position type: "line" or "instr".
+      // e.g. "positions: line"       => 1 position field  (default)
+      //      "positions: instr line" => 2 position fields
+      //      "positions: instr"      => 1 position field
+      this.numPositionFields = headerMatch[2].trim().split(/\s+/).length
+      return true
+    }
 
     if (headerMatch[1] !== 'events') {
       // We don't care about other headers. Ignore this line.
@@ -483,7 +562,8 @@ class CallgrindParser {
         // made. Accounting for the number of calls might be unhelpful anyway,
         // since it'll just be copying the exact same frame over-and-over again,
         // but that might be better than ignoring it.
-        this.parseCostLine(this.lines[this.lineNum++], 'child')
+        const callsLine = this.consumeLine()
+        if (callsLine !== null) this.parseCostLine(callsLine, 'child')
 
         // This isn't specified anywhere in the spec, but empirically the and
         // "cfn" scope should only persist for a single "call".
@@ -500,6 +580,27 @@ class CallgrindParser {
       case 'ob': {
         // We ignore these for now. They're valid lines, but we don't capture or
         // display information about them.
+        break
+      }
+
+      case 'jcnd':
+      case 'jump': {
+        // Jumps aren't modeled; consume the following cost line to stay in sync.
+        this.consumeLine()
+        break
+      }
+
+      case 'jfi':
+      case 'jfl': {
+        // Jump target file — analogous to cfi/cfl but for jumps.
+        // We ignore jump targets, but still parse the name for compression table.
+        this.parseNameWithCompression(value, this.savedFileNames)
+        break
+      }
+
+      case 'jfn': {
+        // Jump target function — analogous to cfn but for jumps. Ignored.
+        this.parseNameWithCompression(value, this.savedFunctionNames)
         break
       }
 
@@ -548,9 +649,11 @@ class CallgrindParser {
   private prevCostLineNumbers: number[] = []
 
   private parseCostLine(line: string, costType: 'self' | 'child'): boolean {
-    // TODO(jlfwong): Allow hexadecimal encoding
-
-    const parts = line.split(/\s+/)
+    // trimEnd() strips trailing whitespace before splitting. Without this,
+    // callgrind lines with trailing spaces produce a spurious empty token
+    // in the split result (e.g. "* * " -> ["*","*",""]), causing valid
+    // subposition-compressed cost lines to be incorrectly rejected.
+    const parts = line.replace(/\s+$/, '').split(/\s+/)
     const nums: number[] = []
 
     for (let i = 0; i < parts.length; i++) {
@@ -560,7 +663,7 @@ class CallgrindParser {
         return false
       }
 
-      if (part === '*' || part[0] === '-' || part[1] === '+') {
+      if (part === '*' || part[0] === '-' || part[0] === '+') {
         // This handles "Subposition compression"
         // See: https://valgrind.org/docs/manual/cl-format.html#cl-format.overview.compression2
         if (this.prevCostLineNumbers.length <= i) {
@@ -584,8 +687,13 @@ class CallgrindParser {
           }
           nums.push(prevCostForSubposition + offset)
         }
+      } else if (/^0x[0-9a-fA-F]+$/.test(part)) {
+        // Hexadecimal instruction address used as a position field.
+        // Parse it so subposition compression works on subsequent lines,
+        // but the value itself is only used as a position (not a cost).
+        nums.push(parseInt(part, 16))
       } else {
-        const asNum = parseInt(part)
+        const asNum = parseInt(part, 10)
         if (isNaN(asNum)) {
           return false
         }
@@ -597,8 +705,7 @@ class CallgrindParser {
       return false
     }
 
-    // TODO(jlfwong): Handle custom positions format w/ multiple parts
-    const numPositionFields = 1
+    const numPositionFields = this.numPositionFields
 
     // NOTE: We intentionally do not include the line number here because
     // callgrind uses the line number of the function invocation, not the
@@ -632,6 +739,6 @@ class CallgrindParser {
 export function importFromCallgrind(
   contents: TextFileContent,
   importedFileName: string,
-): ProfileGroup | null {
+): Promise<ProfileGroup | null> {
   return new CallgrindParser(contents, importedFileName).parse()
 }


### PR DESCRIPTION
Fixes Issue #550

This is a larger-than-usual PR, but the changes are tightly coupled. Each is required to successfully import callgrind.out.* files produced when profiling FreeRADIUS with Valgrind. Splitting them apart would leave the parser in a broken intermediate state.

### Background
The callgrind format allows a `positions:` header that declares how many position columns precede cost values on each cost line. The most common value is `positions: line` (one column), but profilers targeting native code routinely emit `positions: instr line` (two columns) or `positions: instr` (one column).  One example of this would be Valgrind profiles of FreeRADIUS. 

The parser previously hard-coded `numPositionFields = 1`; any file with a non-default `positions:` header would silently produce garbage output. Separately, call graphs that are entirely cyclic (every function has at least one caller) had no natural root nodes and produced an empty flame graph.

The following changes have been made to allow Speedscope to display flame graphs of Valgrind profiles generated by running tests on FreeRADIUS.

### Changes
**`positions: `header support**

- Parse the `positions:` header and store `numPositionFields` (count of whitespace-separated tokens).
- Pass `numPositionFields` into `parseCostLine` so the correct number of leading columns are skipped when extracting cost values.
- Add hex address parsing (`0x…` tokens) so instruction-address position fields are consumed correctly and subposition compression still works on subsequent lines.

**Cyclic call graph fallback**

- After the natural-roots pass, if `rootNodes` is empty, fall back to a residual-weight strategy: compute each frame's total incoming edge weight, subtract it from its total weight, and use frames with positive residual as synthetic roots, visited heaviest-first.
- Add a `visitedGlobally` set to avoid exponential re-expansion of shared nodes reachable from multiple roots.
- Emit a `console.warn` when cycles are detected.

### New tests

- `importFromCallgrind positions instr line` 
  - two-column `positions: instr line`; instruction address skipped, costs parsed correctly
- `importFromCallgrind positions instr`
  - one-column `positions: instr`; hex address consumed, no cost corruption
- `importFromCallgrind instr line subposition compression`
  - subposition compression (`*`, `+N`, `-N`) works correctly across two position columns
- `importFromCallgrind cyclic callgraph`
  -  fully-cyclic graph produces a non-empty flame graph via residual-weight roots

### Reference file
A callgrind.out.* file (1.3 MB, generated by Valgrind while profiling FreeRADIUS) is attached as an example of the type of files we are viewing with Speedscope.

[callgrind.out.20-11.txt](https://github.com/user-attachments/files/28157444/callgrind.out.20-11.txt)
